### PR TITLE
Add sports mafia simulation framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,72 @@
-#### Werewolf
+# Sports Mafia Simulation
+
+This project provides a minimal framework for simulating the **sports mafia** party game.  
+The goal is to allow experimentation with different player strategies and to gather
+statistics over multiple games.
+
+## Game Overview
+
+The implementation roughly follows the [sports mafia rules](https://dom-mafia.ru/sport_mafia_game_rules):
+
+* Ten players participate.
+* Roles consist of seven civilians (one of which is the **sheriff**) and three mafia members (one of which is the **don**).
+* The game alternates between **day** and **night** phases.
+  * During the day each alive player may nominate at most one opponent for elimination and may claim to be the sheriff revealing a check result.
+  * After speeches all alive players vote on the nominated candidates. The player with the most votes is eliminated; ties result in no elimination.
+  * At night special roles act:
+    * The sheriff secretly checks a player and learns if they are mafia.
+    * The don searches for the sheriff.
+    * The mafia collectively choose one player to kill.
+* The game ends when either all mafia members are eliminated (civilians win) or the number of mafia equals or exceeds the number of civilians (mafia win).
+
+## Code Structure
+
+```
+mafia/
+├── actions.py      # Dataclasses describing speeches, votes and round logs
+├── game.py         # Main game engine coordinating day/night cycles
+├── player.py       # Player representation tying a role to a strategy
+├── roles.py        # Role enum and helpers
+├── strategies.py   # Base strategy classes and simple default strategies
+└── simulate.py     # Utility for running multiple games and collecting stats
+```
+
+### Strategies
+
+Every player owns a strategy object. Strategies decide what the player says, how they vote,
+and (for special roles) whom they check or kill.  The framework accepts any user‑defined
+strategy implementing the following methods:
+
+* `speak(player, game) -> SpeechAction`
+* `vote(player, game, nominations) -> Optional[int]`
+* `sheriff_check(player, game, candidates)` *(sheriff only)*
+* `mafia_kill(player, game, candidates)` *(mafia and don)*
+* `don_check(player, game, candidates)` *(don only)*
+
+`game` exposes the full history of previous rounds so strategies can base their decisions on
+past events.
+
+The repository includes simple example strategies:
+
+* **CivilianStrategy** – randomly nominates and votes.
+* **SheriffStrategy** – performs random checks and, upon finding a mafia member, claims
+  to be the sheriff and nominates the discovered mafia.
+* **MafiaStrategy** – attempts to nominate civilians and cooperates with the don to kill
+  discovered sheriffs at night.
+* **DonStrategy** – in addition to mafia behaviour, checks for the sheriff at night and
+  shares the information with fellow mafia members.
+
+## Running a Simulation
+
+Use the helper script to run a batch of games and display win statistics:
+
+```bash
+python -m mafia.simulate 100
+```
+
+The number (`100` in the example) specifies how many games to simulate.
+
+---
+This framework is intentionally lightweight; its main purpose is to provide a base for
+experimenting with more sophisticated strategies or for teaching the fundamentals of the
+sports mafia game.

--- a/mafia/actions.py
+++ b/mafia/actions.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class SheriffClaim:
+    claimant: int
+    target: int
+    is_mafia: bool
+
+@dataclass
+class SpeechAction:
+    nomination: Optional[int] = None
+    claim: Optional[SheriffClaim] = None
+
+@dataclass
+class Vote:
+    voter: int
+    target: Optional[int]
+
+@dataclass
+class CheckResult:
+    checker: int
+    target: int
+    is_mafia: bool
+
+@dataclass
+class DonCheckResult:
+    checker: int
+    target: int
+    is_sheriff: bool
+
+@dataclass
+class DayLog:
+    speeches: dict  # pid -> SpeechAction
+    votes: list  # List[Vote]
+    eliminated: Optional[int]
+
+@dataclass
+class NightLog:
+    sheriff_check: Optional[CheckResult]
+    don_check: Optional[DonCheckResult]
+    kill: Optional[int]
+
+@dataclass
+class RoundLog:
+    day: DayLog
+    night: NightLog

--- a/mafia/game.py
+++ b/mafia/game.py
@@ -1,0 +1,129 @@
+import random
+from typing import List, Optional
+
+from .roles import Role
+from .player import Player
+from .actions import (
+    SpeechAction,
+    Vote,
+    CheckResult,
+    DonCheckResult,
+    DayLog,
+    NightLog,
+    RoundLog,
+)
+
+
+class Game:
+    def __init__(self, players: List[Player]):
+        self.players = players
+        self.history: List[RoundLog] = []
+
+    # Helper methods
+    def get_player(self, pid: int) -> Player:
+        return self.players[pid]
+
+    @property
+    def alive_players(self) -> List[Player]:
+        return [p for p in self.players if p.alive]
+
+    def is_alive(self, pid: int) -> bool:
+        return self.players[pid].alive
+
+    def mafia_count(self) -> int:
+        return sum(1 for p in self.alive_players if p.role.is_mafia())
+
+    def civilian_count(self) -> int:
+        return sum(1 for p in self.alive_players if p.role.is_civilian())
+
+    def check_win(self) -> Optional[Role]:
+        if self.mafia_count() == 0:
+            return Role.CIVILIAN
+        if self.mafia_count() >= self.civilian_count():
+            return Role.MAFIA
+        return None
+
+    def run(self) -> Role:
+        round_no = 1
+        while True:
+            day_log = self.day_phase()
+            winner = self.check_win()
+            night_log = None
+            if not winner:
+                night_log = self.night_phase()
+                winner = self.check_win()
+            self.history.append(RoundLog(day=day_log, night=night_log))
+            if winner:
+                return winner
+            round_no += 1
+
+    # Day phase
+    def day_phase(self) -> DayLog:
+        speeches = {}
+        nominations = []
+        for player in list(self.alive_players):
+            action: SpeechAction = player.speak(self)
+            speeches[player.pid] = action
+            if action.nomination is not None and self.is_alive(action.nomination):
+                if action.nomination not in nominations:
+                    nominations.append(action.nomination)
+        votes = []
+        vote_counts = {pid: 0 for pid in nominations}
+        for player in self.alive_players:
+            vote_target = player.vote(self, nominations)
+            votes.append(Vote(voter=player.pid, target=vote_target))
+            if vote_target in vote_counts:
+                vote_counts[vote_target] += 1
+        eliminated = None
+        if vote_counts:
+            max_votes = max(vote_counts.values())
+            top = [pid for pid, count in vote_counts.items() if count == max_votes]
+            if len(top) == 1:
+                eliminated = top[0]
+                self.players[eliminated].alive = False
+        return DayLog(speeches=speeches, votes=votes, eliminated=eliminated)
+
+    # Night phase
+    def night_phase(self) -> NightLog:
+        sheriff_check = None
+        don_check = None
+        kill = None
+
+        # Sheriff check
+        sheriffs = [p for p in self.alive_players if p.role == Role.SHERIFF]
+        if sheriffs:
+            sheriff = sheriffs[0]
+            candidates = [p.pid for p in self.alive_players if p.pid != sheriff.pid]
+            target = sheriff.sheriff_check(self, candidates)
+            if target is not None and self.is_alive(target):
+                target_player = self.get_player(target)
+                result = target_player.role.is_mafia()
+                sheriff.strategy.remember(target, result)  # type: ignore
+                sheriff_check = CheckResult(checker=sheriff.pid, target=target, is_mafia=result)
+
+        # Don check
+        dons = [p for p in self.alive_players if p.role == Role.DON]
+        if dons:
+            don = dons[0]
+            candidates = [p.pid for p in self.alive_players if p.pid != don.pid]
+            target = don.don_check(self, candidates)
+            if target is not None and self.is_alive(target):
+                is_sheriff = self.get_player(target).role == Role.SHERIFF
+                don.strategy.checked.add(target)  # type: ignore
+                if is_sheriff:
+                    for mafia in self.alive_players:
+                        if mafia.role.is_mafia():
+                            mafia.strategy.known_sheriff = target  # type: ignore
+                don_check = DonCheckResult(checker=don.pid, target=target, is_sheriff=is_sheriff)
+
+        # Mafia kill
+        mafia_players = [p for p in self.alive_players if p.role.is_mafia()]
+        if mafia_players:
+            candidates = [p.pid for p in self.alive_players if not p.role.is_mafia()]
+            suggestions = [m.mafia_kill(self, candidates) for m in mafia_players]
+            suggestions = [s for s in suggestions if s is not None]
+            if suggestions:
+                kill = max(set(suggestions), key=suggestions.count)
+                if self.is_alive(kill):
+                    self.get_player(kill).alive = False
+        return NightLog(sheriff_check=sheriff_check, don_check=don_check, kill=kill)

--- a/mafia/player.py
+++ b/mafia/player.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from .roles import Role
+from .strategies import BaseStrategy
+
+
+@dataclass
+class Player:
+    pid: int
+    role: Role
+    strategy: BaseStrategy
+    alive: bool = True
+
+    def speak(self, game):
+        return self.strategy.speak(self, game)
+
+    def vote(self, game, nominations):
+        return self.strategy.vote(self, game, nominations)
+
+    def sheriff_check(self, game, candidates):
+        return self.strategy.sheriff_check(self, game, candidates)
+
+    def mafia_kill(self, game, candidates):
+        return self.strategy.mafia_kill(self, game, candidates)
+
+    def don_check(self, game, candidates):
+        return self.strategy.don_check(self, game, candidates)

--- a/mafia/roles.py
+++ b/mafia/roles.py
@@ -1,0 +1,13 @@
+from enum import Enum, auto
+
+class Role(Enum):
+    CIVILIAN = auto()
+    MAFIA = auto()
+    SHERIFF = auto()
+    DON = auto()
+
+    def is_mafia(self) -> bool:
+        return self in {Role.MAFIA, Role.DON}
+
+    def is_civilian(self) -> bool:
+        return not self.is_mafia()

--- a/mafia/simulate.py
+++ b/mafia/simulate.py
@@ -1,0 +1,47 @@
+import random
+from collections import Counter
+from typing import Dict
+
+from .roles import Role
+from .player import Player
+from .strategies import CivilianStrategy, SheriffStrategy, MafiaStrategy, DonStrategy
+from .game import Game
+
+
+def create_game() -> Game:
+    roles = [Role.SHERIFF] + [Role.CIVILIAN] * 6 + [Role.DON] + [Role.MAFIA] * 2
+    random.shuffle(roles)
+    players = []
+    for pid, role in enumerate(roles):
+        if role == Role.CIVILIAN:
+            strat = CivilianStrategy()
+        elif role == Role.SHERIFF:
+            strat = SheriffStrategy()
+        elif role == Role.DON:
+            strat = DonStrategy()
+        else:
+            strat = MafiaStrategy()
+        players.append(Player(pid=pid, role=role, strategy=strat))
+    return Game(players)
+
+
+def simulate_games(n: int) -> Dict[Role, int]:
+    results = Counter()
+    for _ in range(n):
+        game = create_game()
+        winner = game.run()
+        results[winner] += 1
+    return results
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Simulate sports mafia games")
+    parser.add_argument("n", type=int, nargs="?", default=10, help="Number of games to simulate")
+    args = parser.parse_args()
+
+    results = simulate_games(args.n)
+    total = sum(results.values())
+    for role, count in results.items():
+        print(f"{role.name} wins: {count} ({count/total:.1%})")

--- a/mafia/strategies.py
+++ b/mafia/strategies.py
@@ -1,0 +1,103 @@
+import random
+from typing import List, Optional
+
+from .actions import SpeechAction, SheriffClaim
+from .roles import Role
+
+
+class BaseStrategy:
+    """Base strategy implementing random behavior."""
+
+    def speak(self, player, game) -> SpeechAction:
+        return SpeechAction()
+
+    def vote(self, player, game, nominations: List[int]) -> Optional[int]:
+        return random.choice(nominations) if nominations else None
+
+    # Night actions: subclasses may override
+    def sheriff_check(self, player, game, candidates: List[int]) -> Optional[int]:
+        return None
+
+    def mafia_kill(self, player, game, candidates: List[int]) -> Optional[int]:
+        return None
+
+    def don_check(self, player, game, candidates: List[int]) -> Optional[int]:
+        return None
+
+
+class CivilianStrategy(BaseStrategy):
+    def speak(self, player, game) -> SpeechAction:
+        alive = [p.pid for p in game.alive_players if p.pid != player.pid]
+        nomination = None
+        if alive and random.random() < 0.3:
+            nomination = random.choice(alive)
+        return SpeechAction(nomination=nomination)
+
+
+class SheriffStrategy(CivilianStrategy):
+    def __init__(self):
+        self.known = {}  # pid -> is_mafia
+        self.last_check: Optional[int] = None
+
+    def sheriff_check(self, player, game, candidates: List[int]) -> Optional[int]:
+        unknown = [pid for pid in candidates if pid not in self.known]
+        if not unknown:
+            unknown = candidates
+        target = random.choice(unknown)
+        return target
+
+    def speak(self, player, game) -> SpeechAction:
+        # If we found a mafia, claim and nominate
+        mafia_targets = [pid for pid, is_mafia in self.known.items() if is_mafia and game.is_alive(pid)]
+        if mafia_targets:
+            target = mafia_targets[0]
+            claim = SheriffClaim(claimant=player.pid, target=target, is_mafia=True)
+            return SpeechAction(nomination=target, claim=claim)
+        return super().speak(player, game)
+
+    def remember(self, target: int, is_mafia: bool):
+        self.known[target] = is_mafia
+        self.last_check = target
+
+    def vote(self, player, game, nominations: List[int]) -> Optional[int]:
+        mafia_targets = [pid for pid in nominations if pid in self.known and self.known[pid]]
+        options = mafia_targets or nominations
+        return random.choice(options) if options else None
+
+
+class MafiaStrategy(BaseStrategy):
+    def __init__(self):
+        self.known_sheriff: Optional[int] = None
+
+    def speak(self, player, game) -> SpeechAction:
+        civilians = [p.pid for p in game.alive_players if not p.role.is_mafia()]
+        nomination = None
+        if civilians and random.random() < 0.3:
+            nomination = random.choice(civilians)
+        return SpeechAction(nomination=nomination)
+
+    def mafia_kill(self, player, game, candidates: List[int]) -> Optional[int]:
+        if self.known_sheriff and self.known_sheriff in candidates:
+            return self.known_sheriff
+        return random.choice(candidates)
+
+    def vote(self, player, game, nominations: List[int]) -> Optional[int]:
+        civilians = [pid for pid in nominations if not game.get_player(pid).role.is_mafia()]
+        options = civilians or nominations
+        return random.choice(options) if options else None
+
+
+class DonStrategy(MafiaStrategy):
+    def __init__(self):
+        super().__init__()
+        self.checked: set[int] = set()
+
+    def don_check(self, player, game, candidates: List[int]) -> Optional[int]:
+        options = [pid for pid in candidates if pid not in self.checked]
+        if not options:
+            options = candidates
+        target = random.choice(options)
+        return target
+
+    def remember_sheriff(self, pid: int):
+        self.known_sheriff = pid


### PR DESCRIPTION
## Summary
- Implement core game engine for sports mafia including day and night phases
- Provide role-based strategies for civilians, sheriff, mafia, and don
- Add simulation script and comprehensive README for running multiple games

## Testing
- `pytest -q`
- `python -m mafia.simulate 5`

------
https://chatgpt.com/codex/tasks/task_e_68984cffd6b88333bd53030c57f74e61