### PR TITLE
feat: enhance simulation logging and speaking order

### DIFF
--- a/mafia/game.py
+++ b/mafia/game.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 
 from .roles import Role
 from .player import Player
+from .logger import GameLogger
 from .actions import (
     SpeechAction,
     Vote,
@@ -15,9 +16,11 @@ from .actions import (
 
 
 class Game:
-    def __init__(self, players: List[Player]):
+    def __init__(self, players: List[Player], logger: Optional[GameLogger] = None):
         self.players = players
         self.history: List[RoundLog] = []
+        self.logger = logger
+        self.day_start_pid = 0
 
     # Helper methods
     def get_player(self, pid: int) -> Player:
@@ -46,11 +49,11 @@ class Game:
     def run(self) -> Role:
         round_no = 1
         while True:
-            day_log = self.day_phase()
+            day_log = self.day_phase(round_no)
             winner = self.check_win()
             night_log = None
             if not winner:
-                night_log = self.night_phase()
+                night_log = self.night_phase(round_no)
                 winner = self.check_win()
             self.history.append(RoundLog(day=day_log, night=night_log))
             if winner:
@@ -58,22 +61,49 @@ class Game:
             round_no += 1
 
     # Day phase
-    def day_phase(self) -> DayLog:
+    def day_phase(self, day_no: int) -> DayLog:
+        if self.logger:
+            self.logger.log(f"day {day_no}")
         speeches = {}
         nominations = []
-        for player in list(self.alive_players):
+        alive = self.alive_players
+        start_index = 0
+        for i, p in enumerate(alive):
+            if p.pid >= self.day_start_pid:
+                start_index = i
+                break
+        ordered_players = alive[start_index:] + alive[:start_index]
+        for player in ordered_players:
             action: SpeechAction = player.speak(self)
             speeches[player.pid] = action
             if action.nomination is not None and self.is_alive(action.nomination):
                 if action.nomination not in nominations:
                     nominations.append(action.nomination)
+                if self.logger:
+                    self.logger.log(
+                        f"player {player.pid + 1} nominates player {action.nomination + 1}"
+                    )
+            if action.claim is not None and self.logger:
+                claim = action.claim
+                self.logger.log(
+                    f"player {claim.claimant + 1} claims {claim.target + 1} is mafia"
+                )
         votes = []
         vote_counts = {pid: 0 for pid in nominations}
+        if self.logger:
+            self.logger.log(f"day {day_no} voting")
         for player in self.alive_players:
             vote_target = player.vote(self, nominations)
             votes.append(Vote(voter=player.pid, target=vote_target))
             if vote_target in vote_counts:
                 vote_counts[vote_target] += 1
+            if self.logger:
+                if vote_target is not None:
+                    self.logger.log(
+                        f"player {player.pid + 1} votes for player {vote_target + 1}"
+                    )
+                else:
+                    self.logger.log(f"player {player.pid + 1} abstains")
         eliminated = None
         if vote_counts:
             max_votes = max(vote_counts.values())
@@ -81,10 +111,25 @@ class Game:
             if len(top) == 1:
                 eliminated = top[0]
                 self.players[eliminated].alive = False
+        if self.logger:
+            if eliminated is not None:
+                self.logger.log(f"player {eliminated + 1} is eliminated")
+            else:
+                self.logger.log("no elimination")
+        # determine next day's starting player
+        if ordered_players:
+            next_pid = ordered_players[0].pid + 1
+            alive_after = [p for p in self.players if p.alive and p.pid >= next_pid]
+            if alive_after:
+                self.day_start_pid = alive_after[0].pid
+            else:
+                self.day_start_pid = next((p.pid for p in self.players if p.alive), 0)
         return DayLog(speeches=speeches, votes=votes, eliminated=eliminated)
 
     # Night phase
-    def night_phase(self) -> NightLog:
+    def night_phase(self, night_no: int) -> NightLog:
+        if self.logger:
+            self.logger.log(f"night {night_no}")
         sheriff_check = None
         don_check = None
         kill = None
@@ -103,6 +148,10 @@ class Game:
                     kill = max(set(suggestions), key=suggestions.count)
             if kill is not None and self.is_alive(kill):
                 self.get_player(kill).alive = False
+                if self.logger:
+                    self.logger.log(f"mafia kill player {kill + 1}")
+            elif self.logger:
+                self.logger.log("mafia kill failed")
 
         # Don check after the kill
         don = next((p for p in self.alive_players if p.role == Role.DON), None)
@@ -117,6 +166,11 @@ class Game:
                         if mafia.role.is_mafia():
                             mafia.strategy.known_sheriff = target  # type: ignore
                 don_check = DonCheckResult(checker=don.pid, target=target, is_sheriff=is_sheriff)
+                if self.logger:
+                    result = "is" if is_sheriff else "is not"
+                    self.logger.log(
+                        f"don checks player {target + 1}: {result} sheriff"
+                    )
 
         # Sheriff check last
         sheriff = next((p for p in self.alive_players if p.role == Role.SHERIFF), None)
@@ -127,5 +181,10 @@ class Game:
                 result = self.get_player(target).role.is_mafia()
                 sheriff.strategy.remember(target, result)  # type: ignore
                 sheriff_check = CheckResult(checker=sheriff.pid, target=target, is_mafia=result)
+                if self.logger:
+                    res = "mafia" if result else "not mafia"
+                    self.logger.log(
+                        f"sheriff checks player {target + 1}: {res}"
+                    )
 
         return NightLog(sheriff_check=sheriff_check, don_check=don_check, kill=kill)

--- a/mafia/logger.py
+++ b/mafia/logger.py
@@ -1,0 +1,18 @@
+class GameLogger:
+    """Logger that can write to stdout and an optional file."""
+
+    def __init__(self, verbose: bool = False, log_to_file: bool = False, filename: str = "simul.log"):
+        self.verbose = verbose
+        self.file = open(filename, "w") if log_to_file else None
+
+    def log(self, message: str) -> None:
+        if self.verbose:
+            print(message)
+        if self.file:
+            self.file.write(message + "\n")
+            self.file.flush()
+
+    def close(self) -> None:
+        if self.file:
+            self.file.close()
+

--- a/mafia/simulate.py
+++ b/mafia/simulate.py
@@ -6,9 +6,10 @@ from .roles import Role
 from .player import Player
 from .strategies import CivilianStrategy, SheriffStrategy, MafiaStrategy, DonStrategy
 from .game import Game
+from .logger import GameLogger
 
 
-def create_game() -> Game:
+def create_game(logger: GameLogger | None = None) -> Game:
     roles = [Role.SHERIFF] + [Role.CIVILIAN] * 6 + [Role.DON] + [Role.MAFIA] * 2
     random.shuffle(roles)
     players = []
@@ -22,13 +23,15 @@ def create_game() -> Game:
         else:
             strat = MafiaStrategy()
         players.append(Player(pid=pid, role=role, strategy=strat))
-    return Game(players)
+    return Game(players, logger=logger)
 
 
-def simulate_games(n: int) -> Dict[Role, int]:
+def simulate_games(n: int, logger: GameLogger | None = None) -> Dict[Role, int]:
     results = Counter()
-    for _ in range(n):
-        game = create_game()
+    for i in range(n):
+        if logger:
+            logger.log(f"game {i + 1}")
+        game = create_game(logger)
         winner = game.run()
         results[winner] += 1
     return results
@@ -39,9 +42,16 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Simulate sports mafia games")
     parser.add_argument("n", type=int, nargs="?", default=10, help="Number of games to simulate")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Log actions to stdout")
+    parser.add_argument("-l", "--log", action="store_true", help="Write action log to simul.log")
     args = parser.parse_args()
 
-    results = simulate_games(args.n)
+    logger = None
+    if args.verbose or args.log:
+        logger = GameLogger(verbose=args.verbose, log_to_file=args.log)
+    results = simulate_games(args.n, logger)
+    if logger:
+        logger.close()
     total = sum(results.values())
     for role, count in results.items():
         print(f"{role.name} wins: {count} ({count/total:.1%})")


### PR DESCRIPTION
## Summary
- add `--verbose` option to print detailed game actions
- support `--log` option to save action history to `simul.log`
- rotate first speaker each day to the next alive player

## Testing
- `python -m mafia.simulate 1 -v`
- `python -m mafia.simulate 1 -v -l`


------
https://chatgpt.com/codex/tasks/task_e_68985bf736788333821830901dba0a10