### PR TITLE
Log starting roles, avoid mafia friendly fire, and expose observable history

### DIFF
--- a/mafia/actions.py
+++ b/mafia/actions.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, List
 
 @dataclass
 class SheriffClaim:
@@ -11,6 +11,13 @@ class SheriffClaim:
 class SpeechAction:
     nomination: Optional[int] = None
     claim: Optional[SheriffClaim] = None
+
+
+@dataclass
+class SpeechLog:
+    """Record of a player's speech in order."""
+    speaker: int
+    action: SpeechAction
 
 @dataclass
 class Vote:
@@ -31,8 +38,8 @@ class DonCheckResult:
 
 @dataclass
 class DayLog:
-    speeches: dict  # pid -> SpeechAction
-    votes: list  # List[Vote]
+    speeches: List[SpeechLog]
+    votes: List[Vote]
     eliminated: Optional[int]
 
 @dataclass
@@ -44,4 +51,4 @@ class NightLog:
 @dataclass
 class RoundLog:
     day: DayLog
-    night: NightLog
+    night: Optional[NightLog]

--- a/mafia/strategies.py
+++ b/mafia/strategies.py
@@ -77,9 +77,12 @@ class MafiaStrategy(BaseStrategy):
         return SpeechAction(nomination=nomination)
 
     def mafia_kill(self, player, game, candidates: List[int]) -> Optional[int]:
-        if self.known_sheriff and self.known_sheriff in candidates:
+        options = [pid for pid in candidates if not game.get_player(pid).role.is_mafia()]
+        if self.known_sheriff and self.known_sheriff in options:
             return self.known_sheriff
-        return random.choice(candidates)
+        if options:
+            return random.choice(options)
+        return None
 
     def vote(self, player, game, nominations: List[int]) -> Optional[int]:
         civilians = [pid for pid in nominations if not game.get_player(pid).role.is_mafia()]


### PR DESCRIPTION
## Summary
- log mafia, don and sheriff players when a game begins
- avoid mafia targeting fellow mafia during night kills
- record ordered speeches and provide per-player views of game history
- simplify history lookup by removing redundant checker-id checks for unique sheriff and don

## Testing
- `python -m pytest`
- `python -m mafia.simulate 1 -v`


------
https://chatgpt.com/codex/tasks/task_e_68985fcf53908333af7024da6bf7db5e