### PR TITLE
Allow default DB path and add GameHistoryDB tests

### DIFF
--- a/mafia/simulate.py
+++ b/mafia/simulate.py
@@ -51,13 +51,19 @@ if __name__ == "__main__":
     parser.add_argument("n", type=int, nargs="?", default=10, help="Number of games to simulate")
     parser.add_argument("-v", "--verbose", action="store_true", help="Log actions to stdout")
     parser.add_argument("-l", "--log", action="store_true", help="Write action log to simul.log")
-    parser.add_argument("--db", type=str, help="Path to SQLite database for storing game summaries")
+    parser.add_argument(
+        "--db",
+        nargs="?",
+        const="games.db",
+        default=None,
+        help="Path to SQLite database for storing game summaries (defaults to games.db)",
+    )
     args = parser.parse_args()
 
     logger = None
     if args.verbose or args.log:
         logger = GameLogger(verbose=args.verbose, log_to_file=args.log)
-    db = GameHistoryDB(args.db) if args.db else None
+    db = GameHistoryDB(args.db) if args.db is not None else None
     results = simulate_games(args.n, logger, db)
     if logger:
         logger.close()

--- a/tests/test_history_db.py
+++ b/tests/test_history_db.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mafia.actions import DayLog, NightLog, RoundLog, SpeechAction, SpeechLog
+from mafia.history import GameHistoryDB
+from mafia.roles import Role
+
+
+def _make_game(nominations: int, kill: bool, elimination: bool):
+    """Create a minimal game object with specified counts."""
+
+    players = [SimpleNamespace(role=Role.CIVILIAN), SimpleNamespace(role=Role.MAFIA)]
+
+    speeches = [
+        SpeechLog(speaker=0, action=SpeechAction(nomination=1))
+        for _ in range(nominations)
+    ]
+    day = DayLog(speeches=speeches, votes=[], eliminated=1 if elimination else None)
+    night = NightLog(
+        sheriff_check=None, don_check=None, kill=0 if kill else None
+    )
+    history = [RoundLog(day=day, night=night)]
+    return SimpleNamespace(players=players, history=history)
+
+
+def test_history_totals(tmp_path):
+    games = [
+        _make_game(1, True, True),
+        _make_game(2, False, True),
+        _make_game(0, True, False),
+        _make_game(3, True, True),
+        _make_game(1, False, False),
+    ]
+
+    expected_noms = sum(
+        1
+        for g in games
+        for r in g.history
+        for s in r.day.speeches
+        if s.action.nomination is not None
+    )
+    expected_kills = sum(
+        1
+        for g in games
+        for r in g.history
+        if r.night and r.night.kill is not None
+    )
+    expected_elims = sum(
+        1
+        for g in games
+        for r in g.history
+        if r.day.eliminated is not None
+    )
+
+    db_path = tmp_path / "games.db"
+    db = GameHistoryDB(db_path)
+    for game in games:
+        db.log_game(game, Role.CIVILIAN)
+
+    cur = db.conn.cursor()
+
+    cur.execute(
+        """
+        SELECT SUM(json_extract(s.value, '$.action.nomination') IS NOT NULL)
+        FROM games g,
+             json_each(g.history, '$.rounds') AS r,
+             json_each(json_extract(g.history, '$.rounds[' || r.key || '].day.speeches')) AS s
+        """
+    )
+    db_noms = cur.fetchone()[0]
+
+    cur.execute(
+        """
+        SELECT SUM(json_extract(r.value, '$.night.kill') IS NOT NULL)
+        FROM games g, json_each(g.history, '$.rounds') AS r
+        """
+    )
+    db_kills = cur.fetchone()[0]
+
+    cur.execute(
+        """
+        SELECT SUM(json_extract(r.value, '$.day.eliminated') IS NOT NULL)
+        FROM games g, json_each(g.history, '$.rounds') AS r
+        """
+    )
+    db_elims = cur.fetchone()[0]
+
+    db.close()
+
+    assert db_noms == expected_noms
+    assert db_kills == expected_kills
+    assert db_elims == expected_elims
+


### PR DESCRIPTION
## Summary
- allow `--db` flag without a path in `simulate.py` (defaults to `games.db`)
- add regression test verifying totals from `GameHistoryDB`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898724874e483338b0862cbccf4cc23