### PR TITLE
Add SingleSheriff strategies and post-death speeches

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ The repository includes simple example strategies:
   discovered sheriffs at night.
 * **DonStrategy** – in addition to mafia behaviour, checks for the sheriff at night and
   shares the information with fellow mafia members.
+* **SingleSheriff strategies** – a coordinated set where civilians trust the first
+  sheriff claimant, the sheriff may randomly reveal each day, and mafia focus on
+  eliminating the sheriff and his confirmed allies.
 
 ## Running a Simulation
 

--- a/mafia/actions.py
+++ b/mafia/actions.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, List
 
 @dataclass
@@ -10,7 +10,7 @@ class SheriffClaim:
 @dataclass
 class SpeechAction:
     nomination: Optional[int] = None
-    claim: Optional[SheriffClaim] = None
+    claims: List[SheriffClaim] = field(default_factory=list)
 
 
 @dataclass

--- a/mafia/player.py
+++ b/mafia/player.py
@@ -24,3 +24,6 @@ class Player:
 
     def don_check(self, game, candidates):
         return self.strategy.don_check(self, game, candidates)
+
+    def last_words(self, game):
+        return self.strategy.last_words(self, game)

--- a/mafia/strategies.py
+++ b/mafia/strategies.py
@@ -2,11 +2,14 @@ import random
 from typing import List, Optional
 
 from .actions import SpeechAction, SheriffClaim
-from .roles import Role
-
-
 class BaseStrategy:
-    """Base strategy implementing random behavior."""
+    """Base strategy implementing random behavior.
+
+    This minimal class provides the interface expected by the game engine.
+    It stores no state and always chooses randomly among the provided
+    options. Subclasses are expected to override the methods relevant to
+    their role.
+    """
 
     def speak(self, player, game) -> SpeechAction:
         return SpeechAction()
@@ -24,8 +27,17 @@ class BaseStrategy:
     def don_check(self, player, game, candidates: List[int]) -> Optional[int]:
         return None
 
+    def last_words(self, player, game) -> SpeechAction:
+        return SpeechAction()
+
 
 class CivilianStrategy(BaseStrategy):
+    """Default civilian behaviour.
+
+    The civilian has no persistent state; it randomly nominates and votes
+    among the alive players.
+    """
+
     def speak(self, player, game) -> SpeechAction:
         alive = [p.pid for p in game.alive_players if p.pid != player.pid]
         nomination = None
@@ -35,6 +47,17 @@ class CivilianStrategy(BaseStrategy):
 
 
 class SheriffStrategy(CivilianStrategy):
+    """Basic sheriff implementation performing random checks.
+
+    Attributes
+    ----------
+    known : dict[int, bool]
+        Mapping from player id to whether the checked player is mafia.
+    last_check : Optional[int]
+        Player id of the most recent night check; used for nominations when
+        a mafia member is discovered.
+    """
+
     def __init__(self):
         self.known = {}  # pid -> is_mafia
         self.last_check: Optional[int] = None
@@ -52,7 +75,7 @@ class SheriffStrategy(CivilianStrategy):
         if mafia_targets:
             target = mafia_targets[0]
             claim = SheriffClaim(claimant=player.pid, target=target, is_mafia=True)
-            return SpeechAction(nomination=target, claim=claim)
+            return SpeechAction(nomination=target, claims=[claim])
         return super().speak(player, game)
 
     def remember(self, target: int, is_mafia: bool):
@@ -66,6 +89,14 @@ class SheriffStrategy(CivilianStrategy):
 
 
 class MafiaStrategy(BaseStrategy):
+    """Baseline mafia behaviour targeting civilians.
+
+    Attributes
+    ----------
+    known_sheriff : Optional[int]
+        Player id of the sheriff if discovered; prioritised for elimination.
+    """
+
     def __init__(self):
         self.known_sheriff: Optional[int] = None
 
@@ -91,6 +122,14 @@ class MafiaStrategy(BaseStrategy):
 
 
 class DonStrategy(MafiaStrategy):
+    """Mafia don strategy that searches for the sheriff at night.
+
+    Attributes
+    ----------
+    checked : set[int]
+        Player ids already investigated to avoid duplicate checks.
+    """
+
     def __init__(self):
         super().__init__()
         self.checked: set[int] = set()
@@ -104,3 +143,235 @@ class DonStrategy(MafiaStrategy):
 
     def remember_sheriff(self, pid: int):
         self.known_sheriff = pid
+
+
+class SingleSheriffCivilianStrategy(BaseStrategy):
+    """Civilian behaviour for the SingleSheriff rule set.
+
+    Attributes
+    ----------
+    sheriff : Optional[int]
+        Player id of the first sheriff claimant trusted by the civilian.
+    checked_mafia : set[int]
+        Players publicly identified as mafia by the sheriff.
+    checked_civilians : set[int]
+        Players publicly cleared as civilians by the sheriff.
+    _processed_speeches : set[int]
+        Internal ids of speeches that have already been analysed.
+    _next_history_index : int
+        Index into the game history indicating the next round to scan for
+        claims.
+
+    The strategy fully trusts the first sheriff claim it hears. It tracks
+    the sheriff's public checks and avoids nominating or voting for confirmed
+    civilians while prioritising confirmed mafia. To keep processing cheap
+    we remember which speeches have already been analysed.
+    """
+
+    def __init__(self):
+        self.sheriff: Optional[int] = None
+        self.checked_mafia: set[int] = set()
+        self.checked_civilians: set[int] = set()
+        self._processed_speeches: set[int] = set()
+        self._next_history_index = 0
+
+    def _update_claims(self, game):
+        """Incorporate new sheriff claims from past and current speeches."""
+        while self._next_history_index < len(game.history):
+            round_log = game.history[self._next_history_index]
+            for speech in round_log.day.speeches:
+                if id(speech) not in self._processed_speeches:
+                    self._process_speech(speech)
+            self._next_history_index += 1
+        for speech in getattr(game, "current_speeches", []):
+            if id(speech) not in self._processed_speeches:
+                self._process_speech(speech)
+
+    def _process_speech(self, speech):
+        for claim in speech.action.claims:
+            if self.sheriff is None:
+                self.sheriff = claim.claimant
+            if claim.claimant == self.sheriff:
+                if claim.is_mafia:
+                    self.checked_mafia.add(claim.target)
+                else:
+                    self.checked_civilians.add(claim.target)
+        self._processed_speeches.add(id(speech))
+
+    def speak(self, player, game) -> SpeechAction:
+        self._update_claims(game)
+        for target in self.checked_mafia:
+            if game.is_alive(target):
+                return SpeechAction(nomination=target)
+        alive = [
+            p.pid
+            for p in game.alive_players
+            if p.pid != player.pid and p.pid not in self.checked_civilians
+        ]
+        if self.sheriff is not None and self.sheriff in alive:
+            alive.remove(self.sheriff)
+        nomination = None
+        if alive and random.random() < 0.3:
+            nomination = random.choice(alive)
+        return SpeechAction(nomination=nomination)
+
+    def vote(self, player, game, nominations: List[int]) -> Optional[int]:
+        self._update_claims(game)
+        if self.sheriff is not None:
+            sheriff_speech = next(
+                (s for s in game.current_speeches if s.speaker == self.sheriff),
+                None,
+            )
+            if (
+                sheriff_speech
+                and sheriff_speech.action.nomination is not None
+                and sheriff_speech.action.nomination != player.pid
+                and sheriff_speech.action.nomination in nominations
+            ):
+                return sheriff_speech.action.nomination
+        mafia_targets = [pid for pid in nominations if pid in self.checked_mafia]
+        options = mafia_targets or [pid for pid in nominations if pid not in self.checked_civilians]
+        return random.choice(options) if options else None
+
+
+class SingleSheriffSheriffStrategy(SheriffStrategy):
+    """Sheriff strategy for the SingleSheriff rule set.
+
+    Attributes
+    ----------
+    reveal_probability : float
+        Chance of publicly revealing the role each day while still hidden.
+    revealed : bool
+        Whether the sheriff has already announced himself.
+
+    Each day the sheriff decides randomly whether to reveal himself based on
+    ``reveal_probability``. Once revealed he will continue to speak openly and
+    share all gathered checks. Regardless of being revealed or not, when the
+    sheriff dies he publishes all check results in his last words.
+    """
+
+    def __init__(self, reveal_probability: float = 0.5):
+        super().__init__()
+        self.reveal_probability = reveal_probability
+        self.revealed = False
+
+    def speak(self, player, game) -> SpeechAction:
+        # If still hidden, decide this round whether to reveal
+        if not self.revealed and random.random() < self.reveal_probability:
+            self.revealed = True
+        if self.revealed:
+            claims = [
+                SheriffClaim(claimant=player.pid, target=t, is_mafia=res)
+                for t, res in self.known.items()
+            ]
+            nomination = (
+                self.last_check
+                if self.last_check in self.known and self.known[self.last_check]
+                else None
+            )
+            return SpeechAction(nomination=nomination, claims=claims)
+        return CivilianStrategy.speak(self, player, game)
+
+    def last_words(self, player, game) -> SpeechAction:
+        claims = [
+            SheriffClaim(claimant=player.pid, target=t, is_mafia=res)
+            for t, res in self.known.items()
+        ]
+        return SpeechAction(claims=claims)
+
+    def vote(self, player, game, nominations: List[int]) -> Optional[int]:
+        if self.revealed:
+            mafia_targets = [pid for pid in nominations if pid in self.known and self.known[pid]]
+            options = mafia_targets or nominations
+            return random.choice(options) if options else None
+        return CivilianStrategy.vote(self, player, game, nominations)
+
+
+class SingleSheriffMafiaStrategy(MafiaStrategy):
+    """Mafia behaviour tailored for the SingleSheriff strategies.
+
+    Attributes
+    ----------
+    claimed_sheriff : Optional[int]
+        Player id of the first claimant to the sheriff role.
+    kill_queue : List[int]
+        Ordered list of civilians publicly cleared by the sheriff.
+    _processed_speeches : set[int]
+        Cache of processed speech ids to avoid re-scanning history.
+    _next_history_index : int
+        Index of the next round in the game history to process.
+    known_sheriff : Optional[int]
+        Inherited from :class:`MafiaStrategy`; real sheriff if discovered by the
+        don.
+
+    The mafia prioritise killing a known or claimed sheriff and afterwards any
+    civilians confirmed by the sheriff. To avoid repeatedly scanning the entire
+    history we cache processed speeches.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.claimed_sheriff: Optional[int] = None
+        self.kill_queue: List[int] = []
+        self._processed_speeches: set[int] = set()
+        self._next_history_index = 0
+
+    def _update_claims(self, game):
+        while self._next_history_index < len(game.history):
+            round_log = game.history[self._next_history_index]
+            for speech in round_log.day.speeches:
+                if id(speech) not in self._processed_speeches:
+                    self._process_speech(speech)
+            self._next_history_index += 1
+        for speech in getattr(game, "current_speeches", []):
+            if id(speech) not in self._processed_speeches:
+                self._process_speech(speech)
+
+    def _process_speech(self, speech):
+        for claim in speech.action.claims:
+            if self.claimed_sheriff is None and self.known_sheriff is None:
+                self.claimed_sheriff = claim.claimant
+            if claim.claimant == self.claimed_sheriff or claim.claimant == self.known_sheriff:
+                if not claim.is_mafia and claim.target not in self.kill_queue:
+                    self.kill_queue.append(claim.target)
+        self._processed_speeches.add(id(speech))
+
+    def mafia_kill(self, player, game, candidates: List[int]) -> Optional[int]:
+        self._update_claims(game)
+        self.kill_queue = [pid for pid in self.kill_queue if game.is_alive(pid)]
+        options = [pid for pid in candidates if not game.get_player(pid).role.is_mafia()]
+        if self.known_sheriff is not None and self.known_sheriff in options:
+            return self.known_sheriff
+        if self.claimed_sheriff is not None and self.claimed_sheriff in options:
+            return self.claimed_sheriff
+        if self.kill_queue:
+            target = self.kill_queue.pop(0)
+            if target in options:
+                return target
+        if options:
+            return random.choice(options)
+        return None
+
+
+class SingleSheriffDonStrategy(SingleSheriffMafiaStrategy):
+    """Don variant of the SingleSheriff mafia strategy.
+
+    Attributes
+    ----------
+    checked : set[int]
+        Player ids already investigated at night.
+
+    Behaves like :class:`SingleSheriffMafiaStrategy` but keeps track of players
+    already checked at night to avoid redundant investigations.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.checked: set[int] = set()
+
+    def don_check(self, player, game, candidates: List[int]) -> Optional[int]:
+        options = [pid for pid in candidates if pid not in self.checked]
+        if not options:
+            options = candidates
+        target = random.choice(options)
+        return target

--- a/tests/test_single_sheriff.py
+++ b/tests/test_single_sheriff.py
@@ -1,0 +1,195 @@
+import random
+from mafia.game import Game
+from mafia.player import Player
+from mafia.roles import Role
+from mafia.actions import SpeechAction, SheriffClaim, SpeechLog, RoundLog
+from mafia.strategies import (
+    BaseStrategy,
+    SingleSheriffCivilianStrategy,
+    SingleSheriffSheriffStrategy,
+    SingleSheriffMafiaStrategy,
+    SingleSheriffDonStrategy,
+)
+
+
+class AlwaysKillStrategy(SingleSheriffMafiaStrategy):
+    """Test mafia strategy that always kills a predefined target.
+
+    Attributes
+    ----------
+    target : int
+        Player id that will always be chosen for the night kill.
+    """
+
+    def __init__(self, target):
+        super().__init__()
+        self.target = target
+
+    def mafia_kill(self, player, game, candidates):
+        return self.target
+
+
+class NominateVoteStrategy(BaseStrategy):
+    """Always nominates and votes for player ``0``."""
+
+    def speak(self, player, game):
+        return SpeechAction(nomination=0)
+
+    def vote(self, player, game, nominations):
+        return 0
+
+
+class VoteStrategy(BaseStrategy):
+    """Test strategy that always votes for player ``0``."""
+
+    def vote(self, player, game, nominations):
+        return 0
+
+
+def test_night_victim_speaks_next_day():
+    # Player 1 (mafia) kills player 0 during the first night. On day 2 the
+    # victim should get a speech with no nomination option.
+    players = [
+        Player(0, Role.CIVILIAN, BaseStrategy()),
+        Player(1, Role.DON, AlwaysKillStrategy(target=0)),
+        Player(2, Role.CIVILIAN, BaseStrategy()),
+    ]
+    game = Game(players)
+    day1 = game.day_phase(1)
+    night1 = game.night_phase(1)
+    game.history.append(RoundLog(day=day1, night=night1))
+    day2 = game.day_phase(2)
+    assert day2.speeches[0].speaker == 0  # night victim speaks
+    assert day2.speeches[0].action.nomination is None  # cannot nominate
+
+
+def test_eliminated_player_speaks_after_vote():
+    # Player 1 nominates player 0 and both 1 and 2 vote for him, eliminating
+    # player 0. The eliminated player gets a final speech without nomination.
+    players = [
+        Player(0, Role.CIVILIAN, BaseStrategy()),
+        Player(1, Role.CIVILIAN, NominateVoteStrategy()),
+        Player(2, Role.CIVILIAN, VoteStrategy()),
+    ]
+    game = Game(players)
+    day = game.day_phase(1)
+    assert day.eliminated == 0
+    assert day.speeches[-1].speaker == 0  # eliminated player speaks last
+    assert day.speeches[-1].action.nomination is None  # no nomination allowed
+
+
+def test_single_sheriff_civilian_strategy():
+    # Civilian should trust the sheriff's claim: vote and nominate the
+    # sheriff-checked mafia while avoiding checked civilians.
+    players = [
+        Player(0, Role.SHERIFF, BaseStrategy()),
+        Player(1, Role.MAFIA, BaseStrategy()),
+        Player(2, Role.CIVILIAN, SingleSheriffCivilianStrategy()),
+    ]
+    game = Game(players)
+    game.current_speeches = [
+        SpeechLog(
+            speaker=0,
+            action=SpeechAction(
+                nomination=1,
+                claims=[SheriffClaim(0, 1, True), SheriffClaim(0, 2, False)],
+            ),
+        )
+    ]
+    vote = players[2].vote(game, [1, 2])
+    assert vote == 1  # follows sheriff's vote
+    speech = players[2].speak(game)
+    assert speech.nomination == 1  # nominates checked mafia
+
+
+def test_single_sheriff_sheriff_reveals_after_death():
+    # Even if the sheriff stayed hidden during the game, his last words should
+    # reveal all check results.
+    random.seed(0)
+    strategy = SingleSheriffSheriffStrategy(reveal_probability=0.0)
+    player = Player(0, Role.SHERIFF, strategy)
+    strategy.remember(1, True)
+    strategy.remember(2, False)
+    game = Game([player])
+    action = player.last_words(game)
+    claims = {(c.target, c.is_mafia) for c in action.claims}
+    assert claims == {(1, True), (2, False)}
+
+
+def test_single_sheriff_sheriff_reveal_each_round():
+    """Sheriff should reconsider revealing every time he speaks."""
+
+    strategy = SingleSheriffSheriffStrategy(reveal_probability=0.5)
+    player = Player(0, Role.SHERIFF, strategy)
+    strategy.remember(1, True)
+    game = Game([player])
+
+    # first call: random value > 0.5 -> stays hidden
+    seq = iter([0.6, 0.4])
+
+    def fake_random():
+        return next(seq)
+
+    original_random = random.random
+    random.random = fake_random
+    try:
+        speech1 = player.speak(game)
+        assert not speech1.claims  # hidden, no claims
+        speech2 = player.speak(game)
+        assert [(c.target, c.is_mafia) for c in speech2.claims] == [(1, True)]  # reveals on second call
+    finally:
+        random.random = original_random
+
+
+def test_single_sheriff_mafia_kill_priorities():
+    # Mafia should prioritise killing the real sheriff, then a claimant, then
+    # any civilians confirmed by the sheriff.
+    players = [
+        Player(0, Role.SHERIFF, BaseStrategy()),
+        Player(1, Role.MAFIA, SingleSheriffMafiaStrategy()),
+        Player(2, Role.CIVILIAN, BaseStrategy()),
+        Player(3, Role.CIVILIAN, BaseStrategy()),
+    ]
+    game = Game(players)
+    mafia = players[1]
+    # known sheriff
+    mafia.strategy.known_sheriff = 0
+    target = mafia.mafia_kill(game, [0, 2, 3])
+    assert target == 0
+    # claimed sheriff
+    mafia.strategy.known_sheriff = None
+    game.current_speeches = [
+        SpeechLog(
+            speaker=0,
+            action=SpeechAction(claims=[SheriffClaim(0, 2, False)]),
+        )
+    ]
+    target = mafia.mafia_kill(game, [0, 2, 3])
+    assert target == 0
+    # kill checked civilian
+    mafia.strategy.claimed_sheriff = None
+    mafia.strategy.kill_queue = []
+    mafia.strategy._processed_speeches = set()
+    mafia.strategy._next_history_index = 0
+    mafia.strategy._update_claims(game)
+    mafia.strategy.claimed_sheriff = None
+    game.current_speeches = []
+    target = mafia.mafia_kill(game, [0, 2, 3])
+    assert target == 2
+
+
+def test_single_sheriff_don_check():
+    # Don should avoid checking the same player twice.
+    random.seed(0)
+    strategy = SingleSheriffDonStrategy()
+    player = Player(0, Role.DON, strategy)
+    others = [
+        Player(1, Role.CIVILIAN, BaseStrategy()),
+        Player(2, Role.SHERIFF, BaseStrategy()),
+    ]
+    game = Game([player] + others)
+    candidates = [1, 2]
+    first = player.don_check(game, candidates)
+    strategy.checked.add(first)
+    second = player.don_check(game, candidates)
+    assert first in candidates and second in candidates and first != second


### PR DESCRIPTION
## Summary
- Document strategy attributes across the base and SingleSheriff roles for clearer behaviour
- Clarify SingleSheriff tests with helper strategy docs and step-by-step comments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68987b19dbac8333b458a44c36dc6890