### PR TITLE
Add configuration-driven simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ mafia/
 ├── player.py       # Player representation tying a role to a strategy
 ├── roles.py        # Role enum and helpers
 ├── strategies.py   # Base strategy classes and simple default strategies
+├── config.py       # Load strategy configuration from JSON files
 └── simulate.py     # Utility for running multiple games and collecting stats
 ```
 
@@ -71,6 +72,30 @@ python -m mafia.simulate 100
 ```
 
 The number (`100` in the example) specifies how many games to simulate.
+
+### Using a configuration file
+
+Strategies and their parameters can be described in a JSON file.  Each role
+is mapped to a strategy class name and optional constructor arguments.  For
+example:
+
+```json
+{
+  "CIVILIAN": {"strategy": "CivilianStrategy", "params": {"nomination_prob": 0.2}},
+  "SHERIFF": {"strategy": "SheriffStrategy", "params": {"reveal_prob": 0.8}},
+  "MAFIA": {"strategy": "MafiaStrategy", "params": {"nomination_prob": 0.3}},
+  "DON": {"strategy": "DonStrategy", "params": {"nomination_prob": 0.3}}
+}
+```
+
+Run simulations with the configuration via:
+
+```bash
+python -m mafia.simulate 100 --config config.json
+```
+
+The same configuration can be loaded programmatically with
+``mafia.config.load_config`` and passed to ``simulate_games``.
 
 ---
 This framework is intentionally lightweight; its main purpose is to provide a base for

--- a/mafia/config.py
+++ b/mafia/config.py
@@ -1,0 +1,68 @@
+"""Configuration utilities for the Mafia simulation.
+
+This module defines helpers to construct games from a JSON configuration
+file. The configuration maps each :class:`~mafia.roles.Role` to a strategy
+class name and optional constructor parameters.  It enables running
+simulations without modifying code, facilitating experimentation with
+different player behaviours.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Tuple, Type
+
+from .roles import Role
+from .strategies import (
+    BaseStrategy,
+    CivilianStrategy,
+    DonStrategy,
+    MafiaStrategy,
+    SheriffStrategy,
+    SingleSheriffCivilianStrategy,
+    SingleSheriffDonStrategy,
+    SingleSheriffMafiaStrategy,
+    SingleSheriffSheriffStrategy,
+)
+
+# Mapping from strategy name used in the configuration file to the actual
+# class object.  Users can extend this mapping when providing custom
+# strategies.
+STRATEGIES: Dict[str, Type[BaseStrategy]] = {
+    "CivilianStrategy": CivilianStrategy,
+    "SheriffStrategy": SheriffStrategy,
+    "MafiaStrategy": MafiaStrategy,
+    "DonStrategy": DonStrategy,
+    "SingleSheriffCivilianStrategy": SingleSheriffCivilianStrategy,
+    "SingleSheriffSheriffStrategy": SingleSheriffSheriffStrategy,
+    "SingleSheriffMafiaStrategy": SingleSheriffMafiaStrategy,
+    "SingleSheriffDonStrategy": SingleSheriffDonStrategy,
+}
+
+
+def load_config(path: str | Path) -> Dict[Role, Tuple[Type[BaseStrategy], dict]]:
+    """Load a simulation configuration from a JSON file.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to a JSON file describing strategies per role.
+
+    Returns
+    -------
+    dict
+        Mapping of :class:`Role` to ``(strategy_class, params)`` tuples.
+    """
+
+    with open(path, "r", encoding="utf-8") as fh:
+        raw = json.load(fh)
+
+    config: Dict[Role, Tuple[Type[BaseStrategy], dict]] = {}
+    for role_name, spec in raw.items():
+        role = Role[role_name]
+        strategy_name = spec["strategy"]
+        params = spec.get("params", {})
+        strat_cls = STRATEGIES[strategy_name]
+        config[role] = (strat_cls, params)
+    return config

--- a/tests/test_config_simulation.py
+++ b/tests/test_config_simulation.py
@@ -1,0 +1,97 @@
+import json
+import random
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mafia.config import load_config
+from mafia.roles import Role
+from mafia.simulate import create_game, simulate_games
+from mafia.strategies import (
+    CivilianStrategy,
+    DonStrategy,
+    MafiaStrategy,
+    SheriffStrategy,
+    SingleSheriffCivilianStrategy,
+    SingleSheriffSheriffStrategy,
+)
+
+
+def test_create_game_from_config(tmp_path):
+    cfg = {
+        "CIVILIAN": {"strategy": "CivilianStrategy", "params": {"nomination_prob": 0.1}},
+        "SHERIFF": {
+            "strategy": "SheriffStrategy",
+            "params": {"nomination_prob": 0.2, "reveal_prob": 0.9},
+        },
+        "MAFIA": {"strategy": "MafiaStrategy", "params": {"nomination_prob": 0.4}},
+        "DON": {"strategy": "DonStrategy", "params": {"nomination_prob": 0.5}},
+    }
+    path = tmp_path / "cfg.json"
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(cfg, fh)
+
+    config = load_config(path)
+    random.seed(0)
+    game = create_game(config=config)
+
+    for p in game.players:
+        if p.role == Role.CIVILIAN:
+            assert isinstance(p.strategy, CivilianStrategy)
+            assert p.strategy.nomination_prob == 0.1
+        elif p.role == Role.SHERIFF:
+            assert isinstance(p.strategy, SheriffStrategy)
+            assert p.strategy.nomination_prob == 0.2
+            assert p.strategy.reveal_prob == 0.9
+        elif p.role == Role.MAFIA:
+            assert isinstance(p.strategy, MafiaStrategy)
+            assert p.strategy.nomination_prob == 0.4
+        elif p.role == Role.DON:
+            assert isinstance(p.strategy, DonStrategy)
+            assert p.strategy.nomination_prob == 0.5
+
+
+def test_single_sheriff_aliases(tmp_path):
+    cfg = {
+        "CIVILIAN": {
+            "strategy": "SingleSheriffCivilianStrategy",
+            "params": {"nomination_prob": 0.4},
+        },
+        "SHERIFF": {
+            "strategy": "SingleSheriffSheriffStrategy",
+            "params": {"reveal_prob": 0.1},
+        },
+        "MAFIA": {"strategy": "SingleSheriffMafiaStrategy"},
+        "DON": {"strategy": "SingleSheriffDonStrategy"},
+    }
+    path = tmp_path / "single.json"
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(cfg, fh)
+
+    config = load_config(path)
+    random.seed(1)
+    game = create_game(config=config)
+
+    civilian = next(p for p in game.players if p.role == Role.CIVILIAN)
+    sheriff = next(p for p in game.players if p.role == Role.SHERIFF)
+
+    assert isinstance(civilian.strategy, SingleSheriffCivilianStrategy)
+    assert civilian.strategy.random_nomination_chance == 0.4
+    assert isinstance(sheriff.strategy, SingleSheriffSheriffStrategy)
+    assert sheriff.strategy.reveal_probability == 0.1
+
+
+def test_simulate_games_with_config(tmp_path):
+    cfg = {
+        "CIVILIAN": {"strategy": "CivilianStrategy"},
+        "SHERIFF": {"strategy": "SheriffStrategy"},
+        "MAFIA": {"strategy": "MafiaStrategy"},
+        "DON": {"strategy": "DonStrategy"},
+    }
+    path = tmp_path / "basic.json"
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(cfg, fh)
+
+    results = simulate_games(2, config=path)
+    assert sum(results.values()) == 2


### PR DESCRIPTION
## Summary
- allow strategies to expose nomination and revelation probabilities
- load strategy definitions from JSON configuration files
- extend simulation utilities and CLI to run games using external configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68988f6e7678833383f02030013346d9