### PR TITLE
Add strategy parameter optimization utilities and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ mafia/
 ├── roles.py        # Role enum and helpers
 ├── strategies.py   # Base strategy classes and simple default strategies
 ├── config.py       # Load strategy configuration from JSON/YAML files
-└── simulate.py     # Utility for running multiple games and collecting stats
+├── simulate.py     # Utility for running multiple games and collecting stats
+└── optimization/   # Helpers to tune strategy parameters via simulations
 ```
 
 ### Strategies
@@ -79,7 +80,8 @@ The number (`100` in the example) specifies how many games to simulate.
 
 Strategies and their parameters can be described in a JSON **or YAML** file.
 Each role is mapped to a strategy class name and optional constructor
-arguments. For example in JSON:
+arguments. For example in JSON. Sample YAML configurations are available
+in the ``example_configs`` directory:
 
 ```json
 {
@@ -101,6 +103,14 @@ The same configuration can be loaded programmatically with
 classes are located by name at runtime, so adding a new strategy class to
 ``mafia.strategies`` automatically makes it available to configuration files
 without further changes.
+
+### Parameter Optimisation
+
+The ``mafia.optimization`` package offers helpers for tuning strategy
+parameters. It runs batches of simulations and applies a simple
+hill-climbing search to discover parameter values that increase the win
+rate for a chosen role. See ``mafia/optimization/README.md`` for usage
+examples.
 
 ---
 This framework is intentionally lightweight; its main purpose is to provide a base for

--- a/example_configs/README.md
+++ b/example_configs/README.md
@@ -1,0 +1,7 @@
+# Example Configurations
+
+This directory contains sample YAML files demonstrating how to configure strategies for each role.
+Use these files with ``mafia.simulate`` via the ``--config`` option or ``mafia.config.load_config``.
+
+* ``basic.yaml`` – default strategies with modest parameter tuning.
+* ``single_sheriff.yaml`` – configuration for the SingleSheriff rule set.

--- a/example_configs/basic.yaml
+++ b/example_configs/basic.yaml
@@ -1,0 +1,17 @@
+CIVILIAN:
+  strategy: CivilianStrategy
+  params:
+    nomination_prob: 0.3
+SHERIFF:
+  strategy: SheriffStrategy
+  params:
+    nomination_prob: 0.2
+    reveal_prob: 0.8
+MAFIA:
+  strategy: MafiaStrategy
+  params:
+    nomination_prob: 0.3
+DON:
+  strategy: DonStrategy
+  params:
+    nomination_prob: 0.3

--- a/example_configs/single_sheriff.yaml
+++ b/example_configs/single_sheriff.yaml
@@ -1,0 +1,16 @@
+CIVILIAN:
+  strategy: SingleSheriffCivilianStrategy
+  params:
+    nomination_prob: 0.3
+SHERIFF:
+  strategy: SingleSheriffSheriffStrategy
+  params:
+    reveal_prob: 0.5
+MAFIA:
+  strategy: SingleSheriffMafiaStrategy
+  params:
+    nomination_prob: 0.2
+DON:
+  strategy: SingleSheriffDonStrategy
+  params:
+    nomination_prob: 0.2

--- a/mafia/optimization/README.md
+++ b/mafia/optimization/README.md
@@ -1,0 +1,11 @@
+# Optimization Helpers
+
+This package provides utilities for tuning strategy parameters by running
+simulations.  The functions use a light-weight hill-climbing search to
+adjust parameters and observe how the win rate changes.
+
+* `optimise_parameter` – tweak a single parameter for one role.
+* `optimise_all` – iteratively optimise parameters for multiple roles.
+
+Both functions accept a `seed` argument so that optimisation runs remain
+reproducible during tests.

--- a/mafia/optimization/__init__.py
+++ b/mafia/optimization/__init__.py
@@ -1,0 +1,168 @@
+"""Parameter optimisation helpers for Mafia strategies.
+
+The module implements simple hill-climbing optimisation to improve
+strategy parameters based on simulation win rates.  It can optimise a
+single role parameter or iterate over multiple roles sequentially.
+While more advanced approaches like `Bayesian optimisation`_ exist, a
+lightweight hill-climbing search is sufficient for small parameter
+spaces and avoids external dependencies.
+
+.. _Bayesian optimisation: https://en.wikipedia.org/wiki/Bayesian_optimization
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Dict, Mapping, Tuple, Type
+
+from ..roles import Role
+from ..strategies import BaseStrategy
+from ..simulate import simulate_games
+
+
+@dataclass
+class OptimisationResult:
+    """Outcome of an optimisation run."""
+
+    value: float
+    win_rate: float
+
+
+def optimise_parameter(
+    role: Role,
+    strategy: Type[BaseStrategy],
+    param: str,
+    start: float,
+    *,
+    step: float = 0.1,
+    games: int = 50,
+    iterations: int = 5,
+    target: Role | None = None,
+    base_config: Mapping[Role, Tuple[Type[BaseStrategy], dict]] | None = None,
+    seed: int | None = None,
+) -> OptimisationResult:
+    """Optimise a single strategy parameter for ``role``.
+
+    The function performs a simple hill-climbing search.  Starting from
+    ``start`` it evaluates the win rate with the parameter nudged up and
+    down by ``step``.  If either direction improves the rate the parameter
+    is updated and the process repeats with a halved step size.
+
+    Parameters
+    ----------
+    role : Role
+        Role whose strategy parameter is optimised.
+    strategy : Type[BaseStrategy]
+        Strategy class to instantiate for ``role``.
+    param : str
+        Name of the constructor argument controlling the parameter.
+    start : float
+        Initial parameter value.
+    step : float, optional
+        Step size for the hill climb, by default ``0.1``.
+    games : int, optional
+        Number of games to simulate per evaluation, by default ``50``.
+    iterations : int, optional
+        Maximum number of optimisation iterations, by default ``5``.
+    target : Role, optional
+        Role whose win rate is measured.  Defaults to ``role``.
+    base_config : mapping, optional
+        Additional configuration for other roles kept constant.
+    seed : int, optional
+        Random seed used for reproducible simulations.
+
+    Returns
+    -------
+    OptimisationResult
+        Final parameter value and corresponding win rate.
+    """
+
+    target = target or role
+    config: Dict[Role, Tuple[Type[BaseStrategy], dict]] = (
+        dict(base_config) if base_config else {}
+    )
+
+    def evaluate(value: float) -> float:
+        cfg = config.copy()
+        cfg[role] = (strategy, {param: value})
+        if seed is not None:
+            random.seed(seed)
+        results = simulate_games(games, config=cfg)
+        total = sum(results.values()) or 1
+        return results.get(target, 0) / total
+
+    current = start
+    best_rate = evaluate(current)
+
+    for _ in range(iterations):
+        improved = False
+        for direction in (-1, 1):
+            trial = current + direction * step
+            rate = evaluate(trial)
+            if rate > best_rate:
+                current, best_rate = trial, rate
+                improved = True
+        if not improved:
+            step /= 2
+    return OptimisationResult(current, best_rate)
+
+
+def optimise_all(
+    params: Mapping[Role, Tuple[Type[BaseStrategy], str, float]],
+    *,
+    step: float = 0.1,
+    games: int = 50,
+    rounds: int = 3,
+    target: Role | None = None,
+    seed: int | None = None,
+) -> Dict[Role, OptimisationResult]:
+    """Optimise parameters for multiple roles sequentially.
+
+    Each round performs a coordinate-descent pass calling
+    :func:`optimise_parameter` for every entry in ``params`` and feeding
+    the updated configuration into subsequent optimisations.
+
+    Parameters
+    ----------
+    params : mapping
+        Mapping of ``Role`` to ``(strategy class, parameter name, start)``.
+    step : float, optional
+        Initial step size used for all parameters, by default ``0.1``.
+    games : int, optional
+        Number of games per evaluation, by default ``50``.
+    rounds : int, optional
+        Number of coordinate-descent rounds, by default ``3``.
+    target : Role, optional
+        Role whose win rate is measured. Defaults to ``Role.CIVILIAN``.
+    seed : int, optional
+        Random seed for reproducibility.
+
+    Returns
+    -------
+    dict
+        Mapping of roles to their optimisation results.
+    """
+
+    target = target or Role.CIVILIAN
+    config: Dict[Role, Tuple[Type[BaseStrategy], dict]] = {}
+    results: Dict[Role, OptimisationResult] = {}
+
+    for _ in range(rounds):
+        for role, (strategy, param, value) in params.items():
+            res = optimise_parameter(
+                role,
+                strategy,
+                param,
+                results.get(role, OptimisationResult(value, 0)).value,
+                step=step,
+                games=games,
+                iterations=1,
+                target=target,
+                base_config=config,
+                seed=seed,
+            )
+            results[role] = res
+            config[role] = (strategy, {param: res.value})
+        step /= 2
+    return results

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1,0 +1,69 @@
+"""Tests for optimisation helpers.
+
+The optimisation routines simulate games to tweak strategy parameters.  These
+tests exercise both the single-parameter helper and the multi-role optimisation
+to ensure they return reasonable win rates and updated values.
+"""
+
+import random
+from mafia.roles import Role
+from mafia.strategies import CivilianStrategy, MafiaStrategy, DonStrategy, SheriffStrategy
+from mafia.optimization import optimise_parameter, optimise_all
+
+
+def test_optimise_parameter_reduces_nomination_prob():
+    """Hill-climb should decrease nomination probability for civilians."""
+
+    # Fix the strategies for other roles so only the Civilian parameter varies.
+    base_config = {
+        Role.MAFIA: (MafiaStrategy, {"nomination_prob": 0.3}),
+        Role.DON: (DonStrategy, {"nomination_prob": 0.3}),
+        Role.SHERIFF: (SheriffStrategy, {"reveal_prob": 1.0, "nomination_prob": 0.3}),
+    }
+
+    # Start the civil nomination probability high and let the optimiser adjust
+    # it; we expect a reduction since nominating randomly hurts civilians.
+    res = optimise_parameter(
+        Role.CIVILIAN,
+        CivilianStrategy,
+        "nomination_prob",
+        0.4,
+        step=0.1,
+        games=20,
+        iterations=2,
+        target=Role.CIVILIAN,
+        base_config=base_config,
+        seed=0,
+    )
+
+    # The returned value should be lower than the starting point and produce a
+    # sensible win rate within [0, 1].
+    assert res.value < 0.4
+    assert 0 <= res.win_rate <= 1
+
+
+def test_optimise_all_returns_results():
+    """Optimising multiple roles should return a result for each."""
+
+    # Describe the parameters to optimise for each role.  Each tuple contains
+    # the strategy class, the parameter name, and the starting value.
+    params = {
+        Role.CIVILIAN: (CivilianStrategy, "nomination_prob", 0.3),
+        Role.MAFIA: (MafiaStrategy, "nomination_prob", 0.3),
+    }
+
+    # Run a single coordinate-descent round with a small number of games to
+    # keep the test fast.
+    results = optimise_all(
+        params,
+        step=0.1,
+        games=10,
+        rounds=1,
+        target=Role.CIVILIAN,
+        seed=0,
+    )
+
+    # Ensure we get an OptimisationResult for each role and that win rates are
+    # valid probabilities.
+    assert set(results) == {Role.CIVILIAN, Role.MAFIA}
+    assert all(0 <= r.win_rate <= 1 for r in results.values())


### PR DESCRIPTION
## Summary
- add example YAML configurations in new `example_configs` directory
- introduce `mafia.optimization` helpers for tuning strategy parameters using hill-climbing search
- document and test optimization utilities and update README
- expand optimization tests with explanatory comments for clarity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68989edd7b4c83338a8eb11abf010cad