### PR TITLE
Handle tie vote revotes and mass elimination

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The implementation roughly follows the [sports mafia rules](https://dom-mafia.ru
 * Roles consist of seven civilians (one of which is the **sheriff**) and three mafia members (one of which is the **don**).
 * The game alternates between **day** and **night** phases.
   * During the day each alive player may nominate at most one opponent for elimination and may claim to be the sheriff revealing a check result.
-  * After speeches all alive players vote on the nominated candidates. If at least one candidate exists every player must cast a vote. The player with the most votes is eliminated; ties result in no elimination.
+  * After speeches all alive players vote on the nominated candidates. If at least one candidate exists every player must cast a vote; failing to choose assigns the vote to the last nominated player. The player with the most votes is eliminated. When multiple candidates tie for the most votes, a revote is held among the tied players. If the revote also ties, the table votes on whether all tied players should be eliminated. An absolute majority eliminates all of them; otherwise nobody is removed.
   * At night special roles act:
     * The sheriff secretly checks a player and learns if they are mafia. If the sheriff is killed during the night they still perform this final check before dying at dawn.
     * The don searches for the sheriff.

--- a/mafia/actions.py
+++ b/mafia/actions.py
@@ -55,7 +55,7 @@ class DayLog:
 
     speeches: List[SpeechLog]
     votes: List[Vote]
-    eliminated: Optional[int]
+    eliminated: Optional[List[int]]
 
 @dataclass
 class NightLog:

--- a/mafia/player.py
+++ b/mafia/player.py
@@ -23,6 +23,25 @@ class Player:
     def vote(self, game, nominations):
         return self.strategy.vote(self, game, nominations)
 
+    def vote_elimination(self, game, candidates):
+        """Decide whether all tied candidates should be eliminated.
+
+        Parameters
+        ----------
+        game : Game
+            Current game instance.
+        candidates : list[int]
+            Player ids who remain tied after a revote.
+
+        Returns
+        -------
+        bool
+            ``True`` if the player supports eliminating all tied candidates,
+            ``False`` otherwise.
+        """
+
+        return self.strategy.vote_elimination(self, game, candidates)
+
     def sheriff_check(self, game, candidates):
         return self.strategy.sheriff_check(self, game, candidates)
 

--- a/mafia/strategies.py
+++ b/mafia/strategies.py
@@ -19,6 +19,32 @@ class BaseStrategy:
     def vote(self, player, game, nominations: List[int]) -> Optional[int]:
         return random.choice(nominations) if nominations else None
 
+    def vote_elimination(self, player, game, candidates: List[int]) -> bool:
+        """Decide whether all tied candidates should be eliminated.
+
+        Parameters
+        ----------
+        player : Player
+            Acting player instance.
+        game : Game
+            Current game state.
+        candidates : list[int]
+            Player ids tied after a revote.
+
+        Returns
+        -------
+        bool
+            ``True`` to eliminate all tied players, ``False`` to keep them.
+
+        Notes
+        -----
+        The base implementation is conservative and always votes against
+        eliminating all tied candidates. Strategies can override this method
+        to implement custom behaviour.
+        """
+
+        return False
+
     # Night actions: subclasses may override
     def sheriff_check(self, player, game, candidates: List[int]) -> Optional[int]:
         return None

--- a/tests/test_history_db.py
+++ b/tests/test_history_db.py
@@ -18,7 +18,7 @@ def _make_game(nominations: int, kill: bool, elimination: bool):
         SpeechLog(speaker=0, action=SpeechAction(nomination=1))
         for _ in range(nominations)
     ]
-    day = DayLog(speeches=speeches, votes=[], eliminated=1 if elimination else None)
+    day = DayLog(speeches=speeches, votes=[], eliminated=[1] if elimination else None)
     night = NightLog(
         sheriff_check=None, don_check=None, kill=0 if kill else None
     )

--- a/tests/test_single_sheriff.py
+++ b/tests/test_single_sheriff.py
@@ -73,7 +73,7 @@ def test_eliminated_player_speaks_after_vote():
     ]
     game = Game(players)
     day = game.day_phase(1)
-    assert day.eliminated == 0
+    assert day.eliminated == [0]
     assert day.speeches[-1].speaker == 0  # eliminated player speaks last
     assert day.speeches[-1].action.nomination is None  # no nomination allowed
 


### PR DESCRIPTION
## Summary
- document day-phase tie resolution and streamline vote handling
- ensure abstain logs only appear when no nominations exist
- simplify last-word handling by iterating over eliminated players directly
- default abstaining votes to the last nominee during both initial and tie-break votes

## Testing
- `pip install pyyaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a3f8ae548333b1c634a3ee2b52e1