### PR TITLE
Add config-driven optimisation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,12 @@ configuration file:
 python -m mafia.optimization example_configs/optimization.yaml
 ```
 
+Additional scenarios include optimising a single parameter
+(`example_configs/optimization_civilian.yaml`) or all parameters of a single
+role (`example_configs/optimization_sheriff.yaml`).
+
 See ``mafia/optimization/README.md`` for more details on the configuration
-format and additional examples.
+format and further examples.
 
 ---
 This framework is intentionally lightweight; its main purpose is to provide a base for

--- a/README.md
+++ b/README.md
@@ -109,8 +109,16 @@ without further changes.
 The ``mafia.optimization`` package offers helpers for tuning strategy
 parameters. It runs batches of simulations and applies a simple
 hill-climbing search to discover parameter values that increase the win
-rate for a chosen role. See ``mafia/optimization/README.md`` for usage
-examples.
+rate for a chosen role. Multiple parameters per role can be tuned in a
+single run. Optimisations can be launched from the command line using a
+configuration file:
+
+```bash
+python -m mafia.optimization example_configs/optimization.yaml
+```
+
+See ``mafia/optimization/README.md`` for more details on the configuration
+format and additional examples.
 
 ---
 This framework is intentionally lightweight; its main purpose is to provide a base for

--- a/example_configs/README.md
+++ b/example_configs/README.md
@@ -5,3 +5,5 @@ Use these files with ``mafia.simulate`` via the ``--config`` option or ``mafia.c
 
 * ``basic.yaml`` – default strategies with modest parameter tuning.
 * ``single_sheriff.yaml`` – configuration for the SingleSheriff rule set.
+* ``optimization.yaml`` – example setup for ``mafia.optimization`` showcasing
+  multi-parameter tuning.

--- a/example_configs/README.md
+++ b/example_configs/README.md
@@ -6,4 +6,7 @@ Use these files with ``mafia.simulate`` via the ``--config`` option or ``mafia.c
 * ``basic.yaml`` – default strategies with modest parameter tuning.
 * ``single_sheriff.yaml`` – configuration for the SingleSheriff rule set.
 * ``optimization.yaml`` – example setup for ``mafia.optimization`` showcasing
-  multi-parameter tuning.
+  multi-parameter tuning across roles.
+* ``optimization_civilian.yaml`` – tune a single civilian parameter via the CLI.
+* ``optimization_sheriff.yaml`` – optimise both sheriff parameters while other
+  roles remain fixed.

--- a/example_configs/optimization.yaml
+++ b/example_configs/optimization.yaml
@@ -1,0 +1,27 @@
+# Sample optimisation configuration used by mafia.optimization
+# This example tunes both the civilian nomination probability and two
+# sheriff parameters while keeping the mafia roles fixed.
+params:
+  CIVILIAN:
+    strategy: CivilianStrategy
+    params:
+      nomination_prob: 0.4
+  SHERIFF:
+    strategy: SheriffStrategy
+    params:
+      nomination_prob: 0.3
+      reveal_prob: 1.0
+base:
+  MAFIA:
+    strategy: MafiaStrategy
+    params:
+      nomination_prob: 0.3
+  DON:
+    strategy: DonStrategy
+    params:
+      nomination_prob: 0.3
+games: 20
+rounds: 1
+step: 0.1
+target: CIVILIAN
+seed: 0

--- a/example_configs/optimization_civilian.yaml
+++ b/example_configs/optimization_civilian.yaml
@@ -1,0 +1,12 @@
+# Optimise nomination probability for civilians only.
+params:
+  CIVILIAN:
+    strategy: CivilianStrategy
+    params:
+      nomination_prob: 0.4
+# The remaining roles use their default strategies.
+games: 20
+rounds: 1
+step: 0.1
+target: CIVILIAN
+seed: 0

--- a/example_configs/optimization_sheriff.yaml
+++ b/example_configs/optimization_sheriff.yaml
@@ -1,0 +1,25 @@
+# Optimise all parameters for the sheriff while other roles stay fixed.
+params:
+  SHERIFF:
+    strategy: SheriffStrategy
+    params:
+      nomination_prob: 0.3
+      reveal_prob: 1.0
+base:
+  CIVILIAN:
+    strategy: CivilianStrategy
+    params:
+      nomination_prob: 0.3
+  MAFIA:
+    strategy: MafiaStrategy
+    params:
+      nomination_prob: 0.3
+  DON:
+    strategy: DonStrategy
+    params:
+      nomination_prob: 0.3
+games: 20
+rounds: 1
+step: 0.1
+target: CIVILIAN
+seed: 0

--- a/mafia/optimization/README.md
+++ b/mafia/optimization/README.md
@@ -24,3 +24,20 @@ python -m mafia.optimization example_configs/optimization.yaml
 The configuration format mirrors `example_configs/optimization.yaml` and
 allows specifying which parameters to tune – including multiple parameters
 per role – along with any fixed strategies for other roles.
+
+### Examples
+
+Optimise a **single parameter** for a role:
+
+```bash
+python -m mafia.optimization example_configs/optimization_civilian.yaml
+```
+
+Optimise **all parameters** for a single role:
+
+```bash
+python -m mafia.optimization example_configs/optimization_sheriff.yaml
+```
+
+Roles omitted from the configuration use their default strategies unless a
+`base` section supplies fixed alternatives.

--- a/mafia/optimization/README.md
+++ b/mafia/optimization/README.md
@@ -5,7 +5,22 @@ simulations.  The functions use a light-weight hill-climbing search to
 adjust parameters and observe how the win rate changes.
 
 * `optimise_parameter` – tweak a single parameter for one role.
-* `optimise_all` – iteratively optimise parameters for multiple roles.
+* `optimise_all` – iteratively optimise parameters for multiple roles and
+  supports tuning several parameters for the same role.
+* `optimise_from_config` – load an optimisation run from a JSON/YAML file.
 
 Both functions accept a `seed` argument so that optimisation runs remain
 reproducible during tests.
+
+## Command Line Usage
+
+Optimisations can be executed directly from the shell by pointing the module
+at a configuration file:
+
+```bash
+python -m mafia.optimization example_configs/optimization.yaml
+```
+
+The configuration format mirrors `example_configs/optimization.yaml` and
+allows specifying which parameters to tune – including multiple parameters
+per role – along with any fixed strategies for other roles.

--- a/mafia/optimization/__main__.py
+++ b/mafia/optimization/__main__.py
@@ -1,0 +1,35 @@
+"""CLI entry point for optimisation routines.
+
+Running ``python -m mafia.optimization config.yaml`` executes the hill-climbing
+search described in the configuration file and prints the resulting parameter
+values and win rates.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from . import optimise_from_config
+
+
+def main() -> None:
+    """Parse command line arguments and run the optimiser."""
+
+    parser = argparse.ArgumentParser(
+        description="Optimise strategy parameters via simulations",
+    )
+    parser.add_argument(
+        "config",
+        type=str,
+        help="Path to JSON or YAML optimisation configuration",
+    )
+    args = parser.parse_args()
+
+    results = optimise_from_config(args.config)
+    for role, params in results.items():
+        for param, res in params.items():
+            print(f"{role.name}.{param}: {res.value:.3f} -> {res.win_rate:.1%}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mafia/optimization/config.py
+++ b/mafia/optimization/config.py
@@ -12,7 +12,8 @@ expected to be JSON or YAML with two sections:
 ``base``
     Optional mapping of additional roles that should remain fixed during
     optimisation.  These entries follow the structure used by
-    :func:`mafia.config.load_config`.
+    :func:`mafia.config.load_config`. Roles not listed in either section use
+    the default strategies from :mod:`mafia.simulate`.
 
 Additional top level keys configure the optimisation run itself:
 ``step``, ``games``, ``rounds``, ``target`` and ``seed``.  See

--- a/mafia/optimization/config.py
+++ b/mafia/optimization/config.py
@@ -1,0 +1,100 @@
+"""Load optimisation settings from a configuration file.
+
+This module mirrors :mod:`mafia.config` but describes the parameters to
+optimise rather than the full simulation setup.  The configuration file is
+expected to be JSON or YAML with two sections:
+
+``params``
+    Mapping of role names to optimisation directives.  Each entry specifies
+    a ``strategy`` class name and either a single parameter via ``param`` /
+    ``start`` or a ``params`` mapping of multiple parameters with their
+    starting values.  All listed parameters are tuned sequentially.
+``base``
+    Optional mapping of additional roles that should remain fixed during
+    optimisation.  These entries follow the structure used by
+    :func:`mafia.config.load_config`.
+
+Additional top level keys configure the optimisation run itself:
+``step``, ``games``, ``rounds``, ``target`` and ``seed``.  See
+:func:`mafia.optimization.optimise_all` for their meaning.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Tuple, Type
+
+from ..roles import Role
+from ..strategies import BaseStrategy
+from ..config import _get_strategy_class
+
+
+# Type aliases for readability
+# Each role maps to a strategy class and a dictionary of parameter start values
+ParamSpec = Tuple[Type[BaseStrategy], Dict[str, float]]
+ConfigMap = Dict[Role, Tuple[Type[BaseStrategy], dict]]
+
+
+def _load_raw(path: Path) -> dict:
+    """Return the raw JSON/YAML document as a dictionary."""
+
+    with open(path, "r", encoding="utf-8") as fh:
+        if path.suffix.lower() in {".yaml", ".yml"}:
+            # Import lazily to avoid mandatory PyYAML dependency
+            import yaml  # type: ignore
+
+            return yaml.safe_load(fh) or {}
+        return json.load(fh)
+
+
+def load_optimisation_config(path: str | Path) -> Tuple[Dict[Role, ParamSpec], ConfigMap, dict]:
+    """Parse an optimisation configuration file.
+
+    Parameters
+    ----------
+    path:
+        Location of the JSON/YAML document describing the optimisation
+        parameters.
+
+    Returns
+    -------
+    tuple
+        ``(params, base_config, options)`` where ``params`` maps roles to a
+        strategy class and dictionary of parameter start values suitable for
+        :func:`mafia.optimization.optimise_all`, ``base_config`` holds fixed
+        role strategies and ``options`` contains additional keyword
+        arguments for the optimiser.
+    """
+
+    path = Path(path)
+    raw = _load_raw(path)
+
+    params: Dict[Role, ParamSpec] = {}
+    for role_name, spec in (raw.get("params") or {}).items():
+        role = Role[role_name]
+        strat = _get_strategy_class(spec["strategy"])
+        if "params" in spec:
+            # Multiple parameters specified explicitly
+            param_map = {k: float(v) for k, v in spec["params"].items()}
+        else:
+            # Legacy single-parameter format
+            param_map = {spec["param"]: float(spec["start"])}
+        params[role] = (strat, param_map)
+
+    base_config: ConfigMap = {}
+    for role_name, spec in (raw.get("base") or {}).items():
+        role = Role[role_name]
+        strat = _get_strategy_class(spec["strategy"])
+        opts = spec.get("params", {})
+        base_config[role] = (strat, opts)
+
+    target_name = raw.get("target")
+    options = {
+        "step": raw.get("step", 0.1),
+        "games": raw.get("games", 50),
+        "rounds": raw.get("rounds", 3),
+        "target": Role[target_name] if target_name else Role.CIVILIAN,
+        "seed": raw.get("seed"),
+    }
+    return params, base_config, options

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1,9 +1,11 @@
 """Tests for optimisation helpers.
 
-The optimisation routines simulate games to tweak strategy parameters.  These
+The optimisation routines simulate games to tweak strategy parameters. These
 tests exercise both the single-parameter helper and the multi-role optimisation
 to ensure they return reasonable win rates and updated values.
 """
+
+from pathlib import Path
 
 from mafia.roles import Role
 from mafia.strategies import CivilianStrategy, MafiaStrategy, DonStrategy, SheriffStrategy
@@ -137,3 +139,24 @@ def test_optimise_from_config(tmp_path):
     assert civ.value < 0.4
     assert 0 <= civ.win_rate <= 1
     assert set(results[Role.SHERIFF]) == {"reveal_prob", "nomination_prob"}
+
+
+def test_config_single_param_example():
+    """The single-parameter example config should optimise one value."""
+
+    cfg = Path(__file__).resolve().parent.parent / "example_configs" / "optimization_civilian.yaml"
+    results = optimise_from_config(cfg)
+    assert set(results) == {Role.CIVILIAN}
+    civ = results[Role.CIVILIAN]["nomination_prob"]
+    assert civ.value < 0.4
+    assert 0 <= civ.win_rate <= 1
+
+
+def test_config_single_role_all_params_example():
+    """The single-role example should yield results for all its parameters."""
+
+    cfg = Path(__file__).resolve().parent.parent / "example_configs" / "optimization_sheriff.yaml"
+    results = optimise_from_config(cfg)
+    assert set(results) == {Role.SHERIFF}
+    assert set(results[Role.SHERIFF]) == {"nomination_prob", "reveal_prob"}
+    assert all(0 <= r.win_rate <= 1 for r in results[Role.SHERIFF].values())


### PR DESCRIPTION
## Summary
- Allow optimisation configs to tune multiple parameters per role
- Expand optimisation helpers and CLI to handle and report multi-parameter results
- Document and test multi-parameter optimisation with updated examples

## Testing
- `pytest -q`
- `python -m mafia.optimization example_configs/optimization.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6898ae4498c08333be5ff469e3c7db99