### PR TITLE
Add tqdm progress bars to simulations and optimisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ The repository includes simple example strategies:
 
 ## Running a Simulation
 
-Use the helper script to run a batch of games and display win statistics:
+Use the helper script to run a batch of games and display win statistics. A
+progress bar from `tqdm` keeps track of the simulation progress so longer
+runs can be monitored easily:
 
 ```bash
 python -m mafia.simulate 100
@@ -110,7 +112,8 @@ The ``mafia.optimization`` package offers helpers for tuning strategy
 parameters. It runs batches of simulations and applies a simple
 hill-climbing search to discover parameter values that increase the win
 rate for a chosen role. Multiple parameters per role can be tuned in a
-single run. Optimisations can be launched from the command line using a
+single run. A `tqdm` progress bar reports how many optimisation steps have
+been completed. Optimisations can be launched from the command line using a
 configuration file:
 
 ```bash

--- a/mafia/optimization/README.md
+++ b/mafia/optimization/README.md
@@ -2,7 +2,9 @@
 
 This package provides utilities for tuning strategy parameters by running
 simulations.  The functions use a light-weight hill-climbing search to
-adjust parameters and observe how the win rate changes.
+adjust parameters and observe how the win rate changes.  Progress through
+the optimisation steps is shown via a `tqdm` progress bar so long runs are
+easy to monitor.
 
 * `optimise_parameter` – tweak a single parameter for one role.
 * `optimise_all` – iteratively optimise parameters for multiple roles and

--- a/mafia/simulate.py
+++ b/mafia/simulate.py
@@ -3,6 +3,8 @@ from collections import Counter
 from pathlib import Path
 from typing import Dict, Mapping, Tuple, Type
 
+from tqdm.auto import tqdm
+
 from .roles import Role
 from .player import Player
 from .strategies import (
@@ -61,6 +63,9 @@ def simulate_games(
 ) -> Dict[Role, int]:
     """Run ``n`` games and tally the winners.
 
+    A progress bar is displayed via :mod:`tqdm` so that long simulations
+    provide feedback to the user.
+
     Parameters
     ----------
     n : int
@@ -78,7 +83,9 @@ def simulate_games(
         config = load_config(config)
 
     results = Counter()
-    for i in range(n):
+    # Iterate over the requested number of games while updating a progress bar
+    # so users can track long-running simulations.
+    for i in tqdm(range(n), desc="Simulating games"):
         if logger:
             logger.log(f"game {i + 1}")
         game = create_game(logger, config)

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,52 @@
+"""Tests ensuring progress bars are wired into simulation and optimisation."""
+
+from mafia import simulate, optimization
+from mafia.roles import Role
+from mafia.strategies import CivilianStrategy
+
+
+def test_simulate_games_uses_tqdm(monkeypatch):
+    """Ensure :func:`simulate.simulate_games` delegates to ``tqdm``."""
+
+    calls = {}
+
+    def fake_tqdm(iterable, **kwargs):
+        calls['total'] = len(iterable)
+        return iterable
+
+    monkeypatch.setattr(simulate, 'tqdm', fake_tqdm)
+    simulate.simulate_games(1)
+    assert calls['total'] == 1
+
+
+def test_optimise_all_uses_tqdm(monkeypatch):
+    """Verify optimisation wraps the total round count in ``tqdm``."""
+
+    progress = {'total': 0, 'updates': 0}
+
+    class DummyBar:
+        """Minimal context manager mimicking :class:`tqdm`'s API."""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def update(self, n=1):
+            progress['updates'] += n
+
+    def fake_tqdm(total, **kwargs):
+        progress['total'] = total
+        return DummyBar()
+
+    # Patch tqdm in both optimisation and simulation to avoid real progress output
+    monkeypatch.setattr(optimization, 'tqdm', fake_tqdm)
+    monkeypatch.setattr(simulate, 'tqdm', lambda iterable, **_: iterable)
+
+    params = {Role.CIVILIAN: (CivilianStrategy, {'nomination_prob': 0.3})}
+    optimization.optimise_all(params, rounds=2, games=1, seed=0)
+
+    assert progress['total'] == 2
+    assert progress['updates'] == 2
+


### PR DESCRIPTION
## Summary
- show tqdm progress bar while simulating games
- track optimisation progress with a unified tqdm bar
- document progress indicators and add regression tests
- clarify progress-bar tests with explanatory docstrings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898b9f1aa30833391ba5500a0359710