### PR TITLE
test: silence tqdm by default

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+"""Pytest configuration used across the test suite.
+
+This module ensures that progress bars from :mod:`tqdm` do not clutter
+standard test runs. The progress output is useful when debugging but
+normally hides failures, so we silence it unless the user explicitly asks
+for verbose output with ``-v``.
+"""
+
+from __future__ import annotations
+
+import os
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Run before tests are collected to adjust global test behaviour.
+
+    The ``TQDM_DISABLE`` environment variable tells :mod:`tqdm` to return a
+    plain iterable without emitting a progress bar. Setting it here ensures it
+    is in place before any project modules import :mod:`tqdm` during test
+    collection. When pytest runs with its default verbosity (or with ``-q``),
+    we set the variable so progress output stays silent. Passing ``-v`` leaves
+    progress bars enabled for developers who want extra insight.
+    """
+
+    if config.getoption("verbose") <= 0:
+        # Configure the environment early so every progress bar instantiated by
+        # the code under test remains silent throughout the run.
+        os.environ.setdefault("TQDM_DISABLE", "1")

--- a/tests/test_tqdm_suppression.py
+++ b/tests/test_tqdm_suppression.py
@@ -1,0 +1,18 @@
+"""Tests verifying that progress bar output stays silent during non-verbose runs."""
+
+import os
+import pytest
+
+
+def test_tqdm_disabled_by_default(pytestconfig):
+    """TQDM progress bars should be disabled when pytest runs quietly.
+
+    The fixture in ``conftest`` sets ``TQDM_DISABLE`` for default test runs, so
+    the simulation and optimisation routines execute without emitting noisy
+    progress bars. If a developer wants to inspect progress they can re-run the
+    suite with ``-v`` to keep the bars enabled.
+    """
+
+    if pytestconfig.getoption("verbose") > 0:
+        pytest.skip("Progress bars are expected when verbosity is requested.")
+    assert os.environ.get("TQDM_DISABLE") == "1"


### PR DESCRIPTION
## Summary
- configure pytest to disable `tqdm` progress bars unless `-v` is used
- add regression test verifying the suppression of progress bars in quiet runs

## Testing
- `pytest -q -s`


------
https://chatgpt.com/codex/tasks/task_e_6898bfff47d4833390c0fb49ad012696