### PR TITLE
Add event dispatcher and decouple logging

### DIFF
--- a/mafia/README.md
+++ b/mafia/README.md
@@ -1,0 +1,13 @@
+# Mafia Package
+
+This package contains the core game engine and related utilities.
+
+* `game.py` – coordinates day and night cycles and emits structured events.
+* `events.py` – tiny publish/subscribe dispatcher used by the game.
+* `logger.py` – default logger subscribing to game events.
+* `actions.py`, `player.py`, `roles.py` – fundamental game data structures.
+* `simulate.py` – helpers for running batches of games.
+
+The event system allows custom observers and loggers to be attached without
+modifying the engine.  See the project root `README.md` for an overview and
+examples.

--- a/mafia/events.py
+++ b/mafia/events.py
@@ -1,0 +1,76 @@
+"""Event dispatching utilities for the Mafia game engine.
+
+The dispatcher implements a very small publish/subscribe mechanism.  The
+:class:`~mafia.game.Game` engine emits structured events instead of calling a
+logger directly.  Listeners can subscribe to the following events:
+
+``speech_added``
+    Emitted whenever a new :class:`~mafia.actions.SpeechLog` is recorded.
+    Payload:
+    ``day`` (int)
+        Current day number starting from ``1``.
+    ``index`` (int)
+        Zero based index of the speech within the day.
+    ``speech`` (:class:`~mafia.actions.SpeechLog`)
+        The newly added speech entry.
+
+``vote_cast``
+    Fired when a player casts a vote during the day phase.
+    Payload:
+    ``day`` (int)
+        Current day number.
+    ``voter`` (int)
+        Player id of the voter.
+    ``target`` (int | None)
+        Player id that received the vote or ``None`` for abstain.
+
+``night_action``
+    Covers all night time actions.  The ``action`` field specifies the
+    particular event:
+
+    ``mafia_kill``
+        ``target`` (int | None) - player id targeted for the kill. ``success``
+        (bool) indicates whether the kill succeeded.
+    ``don_check``
+        ``checker`` (int) - don player id, ``target`` (int) - checked player
+        id, ``is_sheriff`` (bool) - whether the target was the sheriff.
+    ``sheriff_check``
+        ``checker`` (int) - sheriff player id, ``target`` (int) - checked
+        player id, ``is_mafia`` (bool) - whether the target was mafia.
+
+Other auxiliary events emitted by :class:`~mafia.game.Game` include
+``day_started`` (payload ``day``), ``night_started`` (payload ``night``),
+``players_eliminated`` (payload ``day`` and ``players`` list), ``no_elimination``
+(payload ``day``) and ``info`` (payload ``message``) for generic strings.
+
+The dispatcher is intentionally tiny; it merely stores a list of callbacks for
+each event name and invokes them in the order they were registered.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Callable, DefaultDict, List
+
+
+class EventDispatcher:
+    """Lightweight synchronous event dispatcher.
+
+    Handlers are registered via :meth:`subscribe` and receive keyword arguments
+    specified by the emitter.  The dispatcher itself performs no error
+    handling; exceptions raised by handlers will propagate to the caller.
+    """
+
+    def __init__(self) -> None:
+        self._handlers: DefaultDict[str, List[Callable[..., None]]] = defaultdict(list)
+
+    def subscribe(self, event: str, handler: Callable[..., None]) -> None:
+        """Register ``handler`` to be invoked when ``event`` is emitted."""
+
+        self._handlers[event].append(handler)
+
+    def emit(self, event: str, **payload: Any) -> None:
+        """Emit ``event`` with ``payload`` to all subscribed handlers."""
+
+        for handler in self._handlers.get(event, []):
+            handler(**payload)

--- a/mafia/logger.py
+++ b/mafia/logger.py
@@ -1,10 +1,94 @@
+from __future__ import annotations
+
+"""Event driven logger for :class:`mafia.game.Game`.
+
+The logger subscribes to events published by an
+:class:`~mafia.events.EventDispatcher` and renders them as human readable
+messages.  It can optionally print to stdout and/or write to a file.
+"""
+
+from typing import Iterable, List
+
+from .events import EventDispatcher
+
+
 class GameLogger:
-    """Logger that can write to stdout and an optional file."""
+    """Listener that records :class:`mafia.game.Game` events."""
 
     def __init__(self, verbose: bool = False, log_to_file: bool = False, filename: str = "simul.log"):
         self.verbose = verbose
         self.file = open(filename, "w") if log_to_file else None
 
+    # ------------------------------------------------------------------
+    # Subscription
+    def attach(self, dispatcher: EventDispatcher) -> None:
+        """Subscribe to all game related events on ``dispatcher``."""
+
+        dispatcher.subscribe("info", self.log)
+        dispatcher.subscribe("day_started", lambda day: self.log(f"day {day}"))
+        dispatcher.subscribe("night_started", lambda night: self.log(f"night {night}"))
+        dispatcher.subscribe("speech_added", self._on_speech)
+        dispatcher.subscribe("vote_cast", self._on_vote)
+        dispatcher.subscribe("night_action", self._on_night)
+        dispatcher.subscribe("players_eliminated", self._on_eliminated)
+        dispatcher.subscribe("no_elimination", lambda day: self.log("no elimination"))
+        dispatcher.subscribe("game_started", self._on_game_start)
+
+    # Handlers ---------------------------------------------------------
+    def _on_game_start(self, mafia: List[int], don: int, sheriff: int) -> None:
+        mafia_list = ", ".join(str(pid + 1) for pid in mafia)
+        self.log(f"mafia: {mafia_list}")
+        self.log(f"don: {don + 1}")
+        self.log(f"sheriff: {sheriff + 1}")
+
+    def _on_speech(self, day: int, index: int, speech) -> None:
+        """Render speeches, nominations and claims."""
+
+        if speech.action.nomination is not None:
+            self.log(
+                f"player {speech.speaker + 1} nominates player {speech.action.nomination + 1}"
+            )
+        if speech.action.claims:
+            for claim in speech.action.claims:
+                res = "mafia" if claim.is_mafia else "not mafia"
+                self.log(
+                    f"player {claim.claimant + 1} claims {claim.target + 1} is {res}"
+                )
+        else:
+            self.log(f"player {speech.speaker + 1} has no claims")
+
+    def _on_vote(self, day: int, voter: int, target: int | None) -> None:
+        if target is None:
+            self.log(f"player {voter + 1} abstains")
+        else:
+            self.log(f"player {voter + 1} votes for player {target + 1}")
+
+    def _on_night(self, night: int, action: str, **payload) -> None:
+        if action == "mafia_kill":
+            if payload.get("success") and payload.get("target") is not None:
+                self.log(f"mafia kill player {payload['target'] + 1}")
+            else:
+                self.log("mafia kill failed")
+        elif action == "don_check":
+            result = "is" if payload.get("is_sheriff") else "is not"
+            self.log(
+                f"don checks player {payload['target'] + 1}: {result} sheriff"
+            )
+        elif action == "sheriff_check":
+            res = "mafia" if payload.get("is_mafia") else "not mafia"
+            self.log(
+                f"sheriff checks player {payload['target'] + 1}: {res}"
+            )
+
+    def _on_eliminated(self, day: int, players: Iterable[int]) -> None:
+        players = list(players)
+        if len(players) == 1:
+            self.log(f"player {players[0] + 1} is eliminated")
+        else:
+            elim_str = ", ".join(str(pid + 1) for pid in players)
+            self.log(f"players {elim_str} are eliminated")
+
+    # Low level I/O ----------------------------------------------------
     def log(self, message: str) -> None:
         if self.verbose:
             print(message)
@@ -15,4 +99,3 @@ class GameLogger:
     def close(self) -> None:
         if self.file:
             self.file.close()
-

--- a/mafia/simulate.py
+++ b/mafia/simulate.py
@@ -16,6 +16,7 @@ from .strategies import (
 )
 from .game import Game
 from .logger import GameLogger
+from .events import EventDispatcher
 from .history import GameHistoryDB
 from .config import load_config
 
@@ -52,7 +53,10 @@ def create_game(
         else:
             strat = MafiaStrategy()
         players.append(Player(pid=pid, role=role, strategy=strat))
-    return Game(players, logger=logger)
+    dispatcher = EventDispatcher()
+    if logger:
+        logger.attach(dispatcher)
+    return Game(players, dispatcher=dispatcher)
 
 
 def simulate_games(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,117 @@
+"""Tests for the event dispatcher and logging behaviour."""
+
+from mafia.actions import SpeechAction, SpeechLog
+from mafia.events import EventDispatcher
+from mafia.game import Game
+from mafia.logger import GameLogger
+from mafia.player import Player
+from mafia.roles import Role
+from mafia.strategies import BaseStrategy
+
+
+class SilentStrategy(BaseStrategy):
+    """Strategy performing no nominations or votes."""
+
+    def speak(self, player, game):
+        return SpeechAction()
+
+    def vote(self, player, game, nominations):
+        return None
+
+
+class NominateStrategy(BaseStrategy):
+    """Strategy nominating a predefined player and voting for them."""
+
+    def __init__(self, nomination, vote_target):
+        self.nomination = nomination
+        self.vote_target = vote_target
+
+    def speak(self, player, game):
+        return SpeechAction(nomination=self.nomination)
+
+    def vote(self, player, game, nominations):
+        return self.vote_target
+
+
+class KillFirstStrategy(BaseStrategy):
+    """Mafia strategy that always kills the first candidate."""
+
+    def mafia_kill(self, player, game, candidates):  # pragma: no cover - deterministic
+        for cand in candidates:
+            if cand != player.pid:
+                return cand
+        return None
+
+
+def test_speech_event_emitted():
+    """Adding a speech results in a ``speech_added`` event."""
+
+    dispatcher = EventDispatcher()
+    events = []
+    dispatcher.subscribe("speech_added", lambda **p: events.append(p))
+    players = [Player(0, Role.CIVILIAN, SilentStrategy())]
+    game = Game(players, dispatcher=dispatcher)
+    game.add_speech(SpeechLog(speaker=0, action=SpeechAction()), day_no=1)
+    assert events and events[0]["speech"].speaker == 0
+
+
+def test_vote_event_emitted():
+    """Casting votes fires ``vote_cast`` events."""
+
+    dispatcher = EventDispatcher()
+    events = []
+    dispatcher.subscribe("vote_cast", lambda **p: events.append(p))
+    players = [
+        Player(0, Role.CIVILIAN, NominateStrategy(1, 1)),
+        Player(1, Role.CIVILIAN, NominateStrategy(0, 0)),
+    ]
+    game = Game(players, dispatcher=dispatcher)
+    game.day_phase(1)
+    assert any(e["voter"] == 1 and e["target"] == 0 for e in events)
+
+
+def test_night_action_event_emitted():
+    """Night actions trigger ``night_action`` events."""
+
+    dispatcher = EventDispatcher()
+    events = []
+    dispatcher.subscribe("night_action", lambda **p: events.append(p))
+    players = [
+        Player(0, Role.MAFIA, KillFirstStrategy()),
+        Player(1, Role.CIVILIAN, SilentStrategy()),
+    ]
+    game = Game(players, dispatcher=dispatcher)
+    game.night_phase(1)
+    assert any(e["action"] == "mafia_kill" for e in events)
+
+
+def test_logging_can_be_suppressed(capsys):
+    """No output is produced when no logger is attached."""
+
+    dispatcher = EventDispatcher()
+    players = [Player(0, Role.CIVILIAN, SilentStrategy())]
+    game = Game(players, dispatcher=dispatcher)
+    game.add_speech(SpeechLog(speaker=0, action=SpeechAction()), day_no=1)
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_custom_logger_can_replace():
+    """A custom logger can subscribe to events and collect messages."""
+
+    dispatcher = EventDispatcher()
+
+    class CollectingLogger(GameLogger):  # pragma: no cover - simple storage
+        def __init__(self):
+            super().__init__(verbose=False)
+            self.messages = []
+
+        def log(self, message: str) -> None:  # type: ignore[override]
+            self.messages.append(message)
+
+    logger = CollectingLogger()
+    logger.attach(dispatcher)
+    players = [Player(0, Role.CIVILIAN, SilentStrategy())]
+    game = Game(players, dispatcher=dispatcher)
+    game.day_phase(1)
+    assert any("day" in m for m in logger.messages)


### PR DESCRIPTION
## Summary
- Introduce lightweight `EventDispatcher` and have `Game` emit structured events for speeches, votes and night actions
- Rework `GameLogger` to subscribe to events and update simulation helpers to attach loggers
- Document new event system and add comprehensive tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689afd4b87c48333a9976fd840e4be82