### PR TITLE
feat: move role actions into roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,12 @@ The repository includes simple example strategies:
 
 ### Role Behaviour
 
-Roles now expose ``perform_night_action`` and ``resolve_day_action`` hooks. The
-:class:`mafia.game.Game` engine calls these methods on each player and merely
-processes the returned outcomes.  This design keeps all role specific logic
-encapsulated within the role/strategy classes, allowing new roles to be added
-without modifying the core engine.
+Roles expose a ``perform_night_action`` hook implemented by small behaviour
+classes per role. The :class:`mafia.game.Game` engine calls this method on each
+player and merely processes the returned outcomes without inspecting role
+types. This design keeps role specific logic encapsulated within the
+role/strategy classes and allows new roles to be added without modifying the
+core engine.
 
 ## Running a Simulation
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ mafia/
 ├── game.py         # Main game engine coordinating day/night cycles
 ├── logger.py       # Default event-based logger
 ├── player.py       # Player representation tying a role to a strategy
-├── roles.py        # Role enum and helpers
+├── roles.py        # Role enum and behaviour hooks
 ├── strategies.py   # Base strategy classes and simple default strategies
 ├── config.py       # Load strategy configuration from JSON/YAML files
 ├── simulate.py     # Utility for running multiple games and collecting stats
@@ -72,6 +72,14 @@ The repository includes simple example strategies:
   simulations to tune how often unaided civilians nominate at random, and the
   mafia and don variants accept ``nomination_prob`` to control how frequently
   they nominate civilians during the day.
+
+### Role Behaviour
+
+Roles now expose ``perform_night_action`` and ``resolve_day_action`` hooks. The
+:class:`mafia.game.Game` engine calls these methods on each player and merely
+processes the returned outcomes.  This design keeps all role specific logic
+encapsulated within the role/strategy classes, allowing new roles to be added
+without modifying the core engine.
 
 ## Running a Simulation
 

--- a/mafia/README.md
+++ b/mafia/README.md
@@ -5,7 +5,9 @@ This package contains the core game engine and related utilities.
 * `game.py` – coordinates day and night cycles and emits structured events.
 * `events.py` – tiny publish/subscribe dispatcher used by the game.
 * `logger.py` – default logger subscribing to game events.
-* `actions.py`, `player.py`, `roles.py` – fundamental game data structures.
+* `actions.py`, `player.py`, `roles.py` – fundamental game data structures. Role
+  classes expose behavioural hooks so the engine can trigger actions without
+  knowing about concrete role types.
 * `simulate.py` – helpers for running batches of games.
 
 The event system allows custom observers and loggers to be attached without

--- a/mafia/README.md
+++ b/mafia/README.md
@@ -6,8 +6,9 @@ This package contains the core game engine and related utilities.
 * `events.py` – tiny publish/subscribe dispatcher used by the game.
 * `logger.py` – default logger subscribing to game events.
 * `actions.py`, `player.py`, `roles.py` – fundamental game data structures. Role
-  classes expose behavioural hooks so the engine can trigger actions without
-  knowing about concrete role types.
+  classes expose ``perform_night_action`` hooks implemented by small behaviour
+  classes so the engine can trigger actions without knowing about concrete
+  role types.
 * `simulate.py` – helpers for running batches of games.
 
 The event system allows custom observers and loggers to be attached without

--- a/mafia/game.py
+++ b/mafia/game.py
@@ -237,7 +237,6 @@ class Game:
             for pid in eliminated:
                 player = self.players[pid]
                 player.eliminate()
-                player.resolve_day_action(self, "eliminated")
             self.dispatcher.emit("players_eliminated", day=day_no, players=eliminated)
         else:
             self.dispatcher.emit("no_elimination", day=day_no)

--- a/mafia/player.py
+++ b/mafia/player.py
@@ -88,17 +88,6 @@ class Player:
 
         return self.role.perform_night_action(self, game)
 
-    def resolve_day_action(self, game, event):
-        """Allow the role to process a day-phase ``event``.
-
-        ``event`` is a free-form string such as ``"eliminated"``.  Most roles do
-        not react to day events and simply return ``None``.  The method exists so
-        future roles can hook into day transitions without the engine needing to
-        know about them.
-        """
-
-        return self.role.resolve_day_action(self, game, event)
-
     def eliminate(self) -> None:
         """Remove the player from the game.
 

--- a/mafia/roles.py
+++ b/mafia/roles.py
@@ -1,4 +1,18 @@
+"""Role enumeration and behaviour helpers.
+
+The :class:`Game` engine interacts with players exclusively through these role
+methods.  This keeps all role specific logic close to the role definition and
+allows the engine to orchestrate phases without knowing which roles are
+present.  Each method returns lightweight data structures that the engine
+interprets generically.
+"""
+
+from __future__ import annotations
+
 from enum import Enum, auto
+from typing import Dict, Optional
+
+from .actions import CheckResult, DonCheckResult
 
 class Role(Enum):
     CIVILIAN = auto()
@@ -11,3 +25,77 @@ class Role(Enum):
 
     def is_civilian(self) -> bool:
         return not self.is_mafia()
+
+    # ------------------------------------------------------------------
+    # Behavioural hooks -------------------------------------------------
+    def perform_night_action(self, player: "Player", game: "Game") -> Dict[str, object]:
+        """Execute this role's night action.
+
+        Parameters
+        ----------
+        player:
+            The :class:`~mafia.player.Player` performing the action.
+        game:
+            Current :class:`~mafia.game.Game` instance.  Strategies may inspect
+            the game state to decide whom to target.
+
+        Returns
+        -------
+        dict
+            A mapping describing the performed action.  Common keys are
+            ``kill``, ``kill_suggestion``, ``sheriff_check`` and ``don_check``.
+            Unknown roles simply return an empty mapping.
+        """
+
+        actions: Dict[str, object] = {}
+        alive_candidates = [p.pid for p in game.alive_players if p.pid != player.pid]
+
+        if self == Role.SHERIFF:
+            target = player.sheriff_check(game, alive_candidates)
+            if target is not None:
+                result = game.get_player(target).role.is_mafia()
+                player.strategy.remember(target, result)  # type: ignore[attr-defined]
+                actions["sheriff_check"] = CheckResult(
+                    checker=player.pid, target=target, is_mafia=result
+                )
+
+        elif self == Role.DON:
+            kill = player.mafia_kill(game, [p.pid for p in game.alive_players])
+            if kill is not None:
+                actions["kill"] = kill
+
+            candidates = [pid for pid in alive_candidates if pid != kill]
+            target = player.don_check(game, candidates)
+            if target is not None:
+                is_sheriff = game.get_player(target).role == Role.SHERIFF
+                player.strategy.checked.add(target)  # type: ignore[attr-defined]
+                if is_sheriff:
+                    for mafia in game.alive_players:
+                        if mafia.role.is_mafia():
+                            mafia.strategy.known_sheriff = target  # type: ignore[attr-defined]
+                actions["don_check"] = DonCheckResult(
+                    checker=player.pid, target=target, is_sheriff=is_sheriff
+                )
+
+        elif self == Role.MAFIA:
+            suggestion = player.mafia_kill(game, [p.pid for p in game.alive_players])
+            if suggestion is not None:
+                actions["kill_suggestion"] = suggestion
+
+        # Civilians perform no night actions
+        return actions
+
+    def resolve_day_action(self, player: "Player", game: "Game", event: str) -> Optional[object]:
+        """React to a day-phase ``event``.
+
+        No built-in role currently reacts to day events, but the hook allows
+        custom roles to implement behaviours such as automatic revelations or
+        passive effects.
+        """
+
+        return None
+
+    def delays_night_death(self) -> bool:
+        """Return ``True`` if a night kill should be applied after all actions."""
+
+        return self == Role.SHERIFF

--- a/tests/test_role_actions.py
+++ b/tests/test_role_actions.py
@@ -1,0 +1,77 @@
+from mafia.game import Game
+from mafia.player import Player
+from mafia.roles import Role
+from mafia.actions import SpeechAction
+from mafia.strategies import BaseStrategy
+
+
+class SimpleSheriffStrategy(BaseStrategy):
+    """Sheriff strategy that deterministically checks player 1."""
+
+    def speak(self, player, game):
+        return SpeechAction()
+
+    def vote(self, player, game, nominations):
+        return None
+
+    def sheriff_check(self, player, game, candidates):
+        return 1 if candidates else None
+
+    def remember(self, target, result):
+        """Record check results; no-op for tests."""
+        pass
+
+
+class KillSheriffStrategy(BaseStrategy):
+    """Mafia/Don strategy that always targets the sheriff."""
+
+    def __init__(self):
+        self.checked = set()
+        self.known_sheriff = None
+
+    def speak(self, player, game):
+        return SpeechAction()
+
+    def vote(self, player, game, nominations):
+        return None
+
+    def mafia_kill(self, player, game, candidates):
+        return 0
+
+    def don_check(self, player, game, candidates):
+        return 3 if candidates else None
+
+
+class PassiveStrategy(BaseStrategy):
+    """Strategy performing no special actions."""
+
+    pass
+
+
+def test_game_delegates_night_actions(monkeypatch):
+    """Night actions are supplied by role hooks rather than Game role checks."""
+
+    players = [
+        Player(0, Role.SHERIFF, SimpleSheriffStrategy()),
+        Player(1, Role.MAFIA, KillSheriffStrategy()),
+        Player(2, Role.DON, KillSheriffStrategy()),
+        Player(3, Role.CIVILIAN, PassiveStrategy()),
+    ]
+    game = Game(players)
+
+    called: list[int] = []
+    original = Role.perform_night_action
+
+    def tracking(self, player, game):
+        called.append(player.pid)
+        return original(self, player, game)
+
+    monkeypatch.setattr(Role, "perform_night_action", tracking)
+    night = game.night_phase(1)
+
+    # All players should have been asked to act
+    assert set(called) == {0, 1, 2, 3}
+    assert night.kill == 0
+    assert night.sheriff_check and night.sheriff_check.target == 1
+    assert night.don_check and night.don_check.target == 3
+    assert not players[0].alive


### PR DESCRIPTION
## Summary
- move night and day action logic into Role and Player classes
- delegate game engine to role hooks and add player life-cycle helpers
- document role encapsulation and add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b0a19ec6c8333b4410cbf8bb27953